### PR TITLE
DT-2616 Search user basic implementation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/data/PrisonCaseload.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/data/PrisonCaseload.kt
@@ -1,0 +1,10 @@
+package uk.gov.justice.digital.hmpps.nomisuserrolesapi.data
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class PrisonCaseload(
+  @Schema(description = "identify for caseload", example = "WWI")
+  val id: String,
+  @Schema(description = "description of caseload, typically prison name", example = "WANDSWORTH (HMP)")
+  val description: String
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/data/PrisonCaseload.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/data/PrisonCaseload.kt
@@ -5,6 +5,6 @@ import io.swagger.v3.oas.annotations.media.Schema
 data class PrisonCaseload(
   @Schema(description = "identify for caseload", example = "WWI")
   val id: String,
-  @Schema(description = "description of caseload, typically prison name", example = "WANDSWORTH (HMP)")
-  val description: String
+  @Schema(description = "name of caseload, typically prison name", example = "WANDSWORTH (HMP)")
+  val name: String
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/data/UserStatus.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/data/UserStatus.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.hmpps.nomisuserrolesapi.data
+
+enum class UserStatus {
+  ALL, ACTIVE, INACTIVE
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/data/UserSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/data/UserSummary.kt
@@ -1,0 +1,18 @@
+package uk.gov.justice.digital.hmpps.nomisuserrolesapi.data
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "Summary User Information")
+data class UserSummary(
+  @Schema(description = "Username", example = "testuser1")
+  val username: String,
+  @Schema(description = "Staff ID", example = "324323")
+  val staffId: Long,
+  @Schema(description = "First name of the user", example = "Mustafa")
+  val firstName: String,
+  @Schema(description = "Last name of the user", example = "Usmani")
+  val lastName: String,
+  @Schema(description = "Account status indicator", example = "trie")
+  val active: Boolean,
+  val activeCaseload: PrisonCaseload?,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/data/UserSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/data/UserSummary.kt
@@ -12,7 +12,8 @@ data class UserSummary(
   val firstName: String,
   @Schema(description = "Last name of the user", example = "Usmani")
   val lastName: String,
-  @Schema(description = "Account status indicator", example = "trie")
+  @Schema(description = "Account status indicator", example = "true")
   val active: Boolean,
+  @Schema(description = "Caseload that is currently active, typically the prison the user is currently working at")
   val activeCaseload: PrisonCaseload?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/jpa/Staff.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/jpa/Staff.kt
@@ -42,7 +42,7 @@ data class Staff(
     return staffId == other.staffId
   }
 
-  override fun hashCode(): Int = 0
+  override fun hashCode(): Int = staffId.hashCode()
 
   @Override
   override fun toString(): String {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/jpa/UserCaseload.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/jpa/UserCaseload.kt
@@ -3,9 +3,9 @@
 package uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa
 
 import org.hibernate.Hibernate
-import org.hibernate.annotations.Type
 import java.io.Serializable
 import java.time.LocalDate
+import java.util.Objects
 import javax.persistence.Column
 import javax.persistence.Embeddable
 import javax.persistence.EmbeddedId
@@ -15,42 +15,44 @@ import javax.persistence.ManyToOne
 import javax.persistence.Table
 
 @Embeddable
-data class LAAAdminUserPk(
-  @Column(name = "LOCAL_AUTHORITY_CODE", nullable = false)
-  var localAuthorityCode: String,
+data class UserCaseloadPk(
+  @Column(name = "CASELOAD_ID", nullable = false)
+  val caseloadId: String,
+
   @Column(name = "USERNAME", nullable = false)
-  var username: String,
+  val username: String,
 ) : Serializable
 
 @Entity
-@Table(name = "LAA_ADMINISTRATORS")
-data class LAAAdminUser(
-
+@Table(name = "USER_ACCESSIBLE_CASELOADS")
+data class UserCaseload(
   @EmbeddedId
-  val id: LAAAdminUserPk,
+  val id: UserCaseloadPk,
 
-  @Column(name = "ACTIVE_FLAG")
-  @Type(type = "yes_no")
-  val active: Boolean,
+  @ManyToOne
+  @JoinColumn(name = "CASELOAD_ID", updatable = false, insertable = false)
+  val caseload: Caseload,
 
-  @Column(name = "EXPIRY_DATE")
-  val expiryDate: LocalDate? = null,
+  @ManyToOne
+  @JoinColumn(name = "USERNAME", updatable = false, insertable = false)
+  val user: UserPersonDetail,
 
-  @ManyToOne(optional = false)
-  @JoinColumn(name = "LOCAL_AUTHORITY_CODE", nullable = false, updatable = false, insertable = false)
-  val authority: LocalAdminAuthority,
+  @JoinColumn(name = "START_DATE")
+  val startDate: LocalDate,
+
 ) {
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
     if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
-    other as LAAAdminUser
+    other as UserCaseload
 
     return id == other.id
   }
 
-  override fun hashCode(): Int = id.hashCode()
+  override fun hashCode(): Int = Objects.hash(id)
 
+  @Override
   override fun toString(): String {
-    return this::class.simpleName + id.toString()
+    return this::class.simpleName + "(EmbeddedId = $id )"
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/jpa/UserGroup.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/jpa/UserGroup.kt
@@ -14,10 +14,10 @@ import javax.persistence.Table
 
 @Entity
 @Table(name = "LOCAL_ADMIN_AUTHORITIES")
-data class LocalAdminAuthority(
+data class UserGroup(
   @Id
   @Column(name = "LOCAL_AUTHORITY_CODE", nullable = false)
-  val localAuthorityCode: String,
+  val id: String,
 
   @Column(name = "DESCRIPTION", nullable = false)
   val description: String,
@@ -34,34 +34,34 @@ data class LocalAdminAuthority(
 
   @OneToMany(fetch = FetchType.LAZY)
   @JoinColumn(name = "LOCAL_AUTHORITY_CODE")
-  val allAdministeredUsers: List<LAAGeneralUser> = listOf(),
+  val activeAndInactiveMembers: List<UserGroupMember> = listOf(),
 
   @OneToMany(fetch = FetchType.LAZY)
   @JoinColumn(name = "LOCAL_AUTHORITY_CODE")
-  val allAdministrators: List<LAAAdminUser> = listOf(),
-
-  @OneToMany(fetch = FetchType.LAZY)
-  @JoinColumn(name = "LOCAL_AUTHORITY_CODE")
-  @Where(clause = "ACTIVE_FLAG = 'Y'")
-  val administeredUsers: List<LAAGeneralUser> = listOf(),
+  val activeAndInactiveAdministrators: List<UserGroupAdministrator> = listOf(),
 
   @OneToMany(fetch = FetchType.LAZY)
   @JoinColumn(name = "LOCAL_AUTHORITY_CODE")
   @Where(clause = "ACTIVE_FLAG = 'Y'")
-  val administrators: List<LAAAdminUser> = listOf(),
+  val members: List<UserGroupMember> = listOf(),
+
+  @OneToMany(fetch = FetchType.LAZY)
+  @JoinColumn(name = "LOCAL_AUTHORITY_CODE")
+  @Where(clause = "ACTIVE_FLAG = 'Y'")
+  val administrators: List<UserGroupAdministrator> = listOf(),
 
 ) {
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
     if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
-    other as LocalAdminAuthority
+    other as UserGroup
 
-    return localAuthorityCode == other.localAuthorityCode
+    return id == other.id
   }
 
-  override fun hashCode(): Int = localAuthorityCode.hashCode()
+  override fun hashCode(): Int = id.hashCode()
 
   override fun toString(): String {
-    return this::class.simpleName + "(code = $localAuthorityCode )"
+    return this::class.simpleName + "(code = $id )"
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/jpa/UserGroupAdministrator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/jpa/UserGroupAdministrator.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DataClassEqualsAndHashCodeInspection")
+
 package uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa
 
 import org.hibernate.Hibernate
@@ -8,48 +10,46 @@ import javax.persistence.Column
 import javax.persistence.Embeddable
 import javax.persistence.EmbeddedId
 import javax.persistence.Entity
-import javax.persistence.FetchType.LAZY
+import javax.persistence.FetchType
 import javax.persistence.JoinColumn
 import javax.persistence.ManyToOne
 import javax.persistence.Table
 
 @Embeddable
-data class LAAGeneralUserPk(
+data class UserGroupAdministratorPk(
   @Column(name = "LOCAL_AUTHORITY_CODE", nullable = false)
-  var localAuthorityCode: String,
+  var userGroupCode: String,
   @Column(name = "USERNAME", nullable = false)
   var username: String,
 ) : Serializable
 
 @Entity
-@Table(name = "LAA_GENERAL_USERS")
-data class LAAGeneralUser(
+@Table(name = "LAA_ADMINISTRATORS")
+data class UserGroupAdministrator(
 
   @EmbeddedId
-  val id: LAAGeneralUserPk,
+  val id: UserGroupAdministratorPk,
 
   @Column(name = "ACTIVE_FLAG")
   @Type(type = "yes_no")
   val active: Boolean,
 
-  @Column(name = "START_DATE")
-  val startDate: LocalDate,
-
   @Column(name = "EXPIRY_DATE")
   val expiryDate: LocalDate? = null,
 
-  @ManyToOne(optional = false)
+  @ManyToOne(optional = false, fetch = FetchType.LAZY)
   @JoinColumn(name = "LOCAL_AUTHORITY_CODE", nullable = false, updatable = false, insertable = false)
-  val authority: LocalAdminAuthority,
+  val userGroup: UserGroup,
 
-  @ManyToOne(fetch = LAZY)
+  @ManyToOne
   @JoinColumn(name = "USERNAME", nullable = false, updatable = false, insertable = false)
   val user: UserPersonDetail,
+
 ) {
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
     if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
-    other as LAAGeneralUser
+    other as UserGroupAdministrator
 
     return id == other.id
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/jpa/UserGroupMember.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/jpa/UserGroupMember.kt
@@ -1,0 +1,63 @@
+package uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa
+
+import org.hibernate.Hibernate
+import org.hibernate.annotations.Type
+import java.io.Serializable
+import java.time.LocalDate
+import javax.persistence.Column
+import javax.persistence.Embeddable
+import javax.persistence.EmbeddedId
+import javax.persistence.Entity
+import javax.persistence.FetchType.LAZY
+import javax.persistence.JoinColumn
+import javax.persistence.ManyToOne
+import javax.persistence.Table
+
+@Suppress("DataClassEqualsAndHashCodeInspection")
+@Embeddable
+data class UserGroupMemberPk(
+  @Column(name = "LOCAL_AUTHORITY_CODE", nullable = false)
+  var userGroupCode: String,
+  @Column(name = "USERNAME", nullable = false)
+  var username: String,
+) : Serializable
+
+@Entity
+@Table(name = "LAA_GENERAL_USERS")
+data class UserGroupMember(
+
+  @EmbeddedId
+  val id: UserGroupMemberPk,
+
+  @Column(name = "ACTIVE_FLAG")
+  @Type(type = "yes_no")
+  val active: Boolean,
+
+  @Column(name = "START_DATE")
+  val startDate: LocalDate,
+
+  @Column(name = "EXPIRY_DATE")
+  val expiryDate: LocalDate? = null,
+
+  @ManyToOne(optional = false, fetch = LAZY)
+  @JoinColumn(name = "LOCAL_AUTHORITY_CODE", nullable = false, updatable = false, insertable = false)
+  val userGroup: UserGroup,
+
+  @ManyToOne
+  @JoinColumn(name = "USERNAME", nullable = false, updatable = false, insertable = false)
+  val user: UserPersonDetail,
+) {
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
+    other as UserGroupMember
+
+    return id == other.id
+  }
+
+  override fun hashCode(): Int = id.hashCode()
+
+  override fun toString(): String {
+    return this::class.simpleName + id.toString()
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/jpa/UserPersonDetail.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/jpa/UserPersonDetail.kt
@@ -8,8 +8,6 @@ import javax.persistence.Entity
 import javax.persistence.FetchType
 import javax.persistence.Id
 import javax.persistence.JoinColumn
-import javax.persistence.JoinTable
-import javax.persistence.ManyToMany
 import javax.persistence.ManyToOne
 import javax.persistence.OneToMany
 import javax.persistence.Table
@@ -30,33 +28,29 @@ data class UserPersonDetail(
   @JoinColumn(name = "USERNAME")
   val roles: List<UserCaseloadRole> = listOf(),
 
-  @ManyToMany(fetch = FetchType.LAZY, cascade = [CascadeType.ALL])
-  @JoinTable(name = "USER_ACCESSIBLE_CASELOADS", joinColumns = [JoinColumn(name = "USERNAME", referencedColumnName = "USERNAME")], inverseJoinColumns = [JoinColumn(name = "CASELOAD_ID", referencedColumnName = "CASELOAD_ID")])
-  val caseloads: List<Caseload> = listOf(),
+  @OneToMany(fetch = FetchType.LAZY, cascade = [CascadeType.ALL], mappedBy = "user")
+  val caseloads: List<UserCaseload> = listOf(),
 
-  @OneToMany(fetch = FetchType.LAZY, cascade = [CascadeType.ALL])
-  @JoinColumn(name = "USERNAME")
+  @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = [CascadeType.ALL], orphanRemoval = true)
+  val activeAndInactiveMemberOfUserGroups: List<UserGroupMember> = listOf(),
+
+  @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
   @Where(clause = "ACTIVE_FLAG = 'Y'")
-  val administeredLinks: List<LAAGeneralUser> = listOf(),
+  val memberOfUserGroups: List<UserGroupMember> = listOf(),
 
-  @OneToMany(fetch = FetchType.LAZY, cascade = [CascadeType.ALL])
-  @JoinColumn(name = "USERNAME")
+  @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = [CascadeType.ALL], orphanRemoval = true)
+  val activeAndInactiveAdministratorOfUserGroups: List<UserGroupAdministrator> = listOf(),
+
+  @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
   @Where(clause = "ACTIVE_FLAG = 'Y'")
-  val administratorLinks: List<LAAAdminUser> = listOf(),
-
-  @OneToMany(fetch = FetchType.LAZY, cascade = [CascadeType.ALL])
-  @JoinColumn(name = "USERNAME")
-  val allAdministeredLinks: List<LAAGeneralUser> = listOf(),
-
-  @OneToMany(fetch = FetchType.LAZY, cascade = [CascadeType.ALL])
-  @JoinColumn(name = "USERNAME")
-  val allAdministratorLinks: List<LAAAdminUser> = listOf(),
+  val administratorOfUserGroups: List<UserGroupAdministrator> = listOf(),
 
   @Column(name = "STAFF_USER_TYPE", nullable = false)
   val type: String,
 
-  @Column(name = "WORKING_CASELOAD_ID")
-  var activeCaseLoadId: String? = null,
+  @JoinColumn(name = "WORKING_CASELOAD_ID", nullable = true, insertable = false, updatable = false)
+  @ManyToOne
+  var activeCaseLoad: Caseload? = null,
 
   @Column(name = "ID_SOURCE")
   var idSource: String = "USER",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/jpa/UserPersonDetail.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/jpa/UserPersonDetail.kt
@@ -48,7 +48,7 @@ data class UserPersonDetail(
   @Column(name = "STAFF_USER_TYPE", nullable = false)
   val type: String,
 
-  @JoinColumn(name = "WORKING_CASELOAD_ID", nullable = true, insertable = false, updatable = false)
+  @JoinColumn(name = "WORKING_CASELOAD_ID", nullable = true)
   @ManyToOne
   var activeCaseLoad: Caseload? = null,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/jpa/repository/UserGroupRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/jpa/repository/UserGroupRepository.kt
@@ -2,7 +2,7 @@ package uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.repository
 
 import org.springframework.data.repository.CrudRepository
 import org.springframework.stereotype.Repository
-import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.LocalAdminAuthority
+import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.UserGroup
 
 @Repository
-interface LocalAdminAuthorityRepository : CrudRepository<LocalAdminAuthority, String>
+interface UserGroupRepository : CrudRepository<UserGroup, String>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/jpa/repository/UserPersonDetailRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/jpa/repository/UserPersonDetailRepository.kt
@@ -1,8 +1,11 @@
 package uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.UserPersonDetail
 
 @Repository
-interface UserPersonDetailRepository : JpaRepository<UserPersonDetail, String>
+interface UserPersonDetailRepository :
+  JpaRepository<UserPersonDetail, String>,
+  JpaSpecificationExecutor<UserPersonDetail>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/jpa/specification/UserSpecification.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/jpa/specification/UserSpecification.kt
@@ -1,0 +1,40 @@
+import org.springframework.data.jpa.domain.Specification
+import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.UserGroup
+import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.UserGroupAdministrator
+import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.UserGroupAdministratorPk
+import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.UserGroupMember
+import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.UserPersonDetail
+import javax.persistence.criteria.CriteriaBuilder
+import javax.persistence.criteria.CriteriaQuery
+import javax.persistence.criteria.Predicate
+import javax.persistence.criteria.Root
+
+class UserSpecification(private val filter: UserFilter) : Specification<UserPersonDetail> {
+  override fun toPredicate(
+    root: Root<UserPersonDetail>,
+    query: CriteriaQuery<*>,
+    criteriaBuilder: CriteriaBuilder
+  ): Predicate? {
+    val predicates = mutableListOf<Predicate>()
+
+    fun administeredBy(localAdministratorUsername: String): Predicate {
+      val memberOfUserGroupsJoin =
+        root.join<UserPersonDetail, UserGroupMember>(UserPersonDetail::memberOfUserGroups.name)
+      val userGroupsJoin = memberOfUserGroupsJoin.join<UserGroupMember, UserGroup>(UserGroupMember::userGroup.name)
+      val administratorsJoin = userGroupsJoin.join<UserGroup, UserGroupAdministrator>(UserGroup::administrators.name)
+      return criteriaBuilder.equal(
+        administratorsJoin.get<UserGroupAdministratorPk>(UserGroupAdministrator::id.name)
+          .get<String>(UserGroupAdministratorPk::username.name),
+        localAdministratorUsername
+      )
+    }
+
+    filter.localAdministratorUsername?.run {
+      predicates.add(administeredBy(this))
+    }
+
+    return criteriaBuilder.and(*predicates.toTypedArray())
+  }
+}
+
+data class UserFilter(val localAdministratorUsername: String? = null)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/jpa/transformer/Transformers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/jpa/transformer/Transformers.kt
@@ -1,0 +1,19 @@
+package uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.transformer
+
+import uk.gov.justice.digital.hmpps.nomisuserrolesapi.data.PrisonCaseload
+import uk.gov.justice.digital.hmpps.nomisuserrolesapi.data.UserSummary
+import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.UserPersonDetail
+
+fun UserPersonDetail.toUserSummary(): UserSummary = UserSummary(
+  username = this.username,
+  staffId = this.staff.staffId,
+  firstName = this.staff.firstName,
+  lastName = this.staff.lastName,
+  active = this.staff.isActive,
+  activeCaseload = this.activeCaseLoad?.let { caseload ->
+    PrisonCaseload(
+      id = caseload.id,
+      name = caseload.name
+    )
+  },
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/resource/UserResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/resource/UserResource.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.nomisuserrolesapi.resource
 
+import UserFilter
 import com.fasterxml.jackson.annotation.JsonInclude
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
@@ -8,7 +9,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.web.PageableDefault
-import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.validation.annotation.Validated
@@ -17,7 +17,6 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
-import org.springframework.web.server.ResponseStatusException
 import uk.gov.justice.digital.hmpps.nomisuserrolesapi.config.AuthenticationFacade
 import uk.gov.justice.digital.hmpps.nomisuserrolesapi.config.ErrorResponse
 import uk.gov.justice.digital.hmpps.nomisuserrolesapi.data.UserStatus
@@ -113,12 +112,11 @@ class UserResource(
       example = "MDI"
     )
     @RequestParam(value = "caseload", required = false) caseload: String?,
-  ): Page<UserSummary> {
-    return userService.getLocalUsers(
-      pageRequest,
-      authenticationFacade.currentUsername ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST)
-    )
-  }
+  ): Page<UserSummary> = userService.getLocalUsers(
+    pageRequest,
+    UserFilter(localAdministratorUsername = localAdministratorUsernameWhenNotCentralAdministrator())
+  )
+  fun localAdministratorUsernameWhenNotCentralAdministrator(): String? = if (AuthenticationFacade.hasRoles("ROLE_MAINTAIN_ACCESS_ROLES_ADMIN")) null else authenticationFacade.currentUsername
 }
 
 @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/resource/UserResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/resource/UserResource.kt
@@ -5,14 +5,23 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.web.PageableDefault
+import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.server.ResponseStatusException
+import uk.gov.justice.digital.hmpps.nomisuserrolesapi.config.AuthenticationFacade
 import uk.gov.justice.digital.hmpps.nomisuserrolesapi.config.ErrorResponse
+import uk.gov.justice.digital.hmpps.nomisuserrolesapi.data.UserStatus
+import uk.gov.justice.digital.hmpps.nomisuserrolesapi.data.UserSummary
 import uk.gov.justice.digital.hmpps.nomisuserrolesapi.service.UserService
 import javax.validation.constraints.NotBlank
 import javax.validation.constraints.Size
@@ -21,7 +30,8 @@ import javax.validation.constraints.Size
 @Validated
 @RequestMapping("/users", produces = [MediaType.APPLICATION_JSON_VALUE])
 class UserResource(
-  private val userService: UserService
+  private val userService: UserService,
+  private val authenticationFacade: AuthenticationFacade,
 ) {
 
   @PreAuthorize("hasRole('ROLE_MAINTAIN_ACCESS_ROLES_ADMIN')")
@@ -52,6 +62,63 @@ class UserResource(
     @PathVariable @Size(max = 30, min = 1, message = "username must be between 1 and 30") username: String
   ): UserDetail =
     userService.findByUsername(username)
+
+  @PreAuthorize("hasRole('ROLE_MAINTAIN_ACCESS_ROLES_ADMIN') or hasRole('ROLE_MAINTAIN_ACCESS_ROLES')")
+  @GetMapping
+  @Operation(
+    summary = "Get all users filtered has specified",
+    description = "Requires role ROLE_MAINTAIN_ACCESS_ROLES_ADMIN or ROLE_MAINTAIN_ACCESS_ROLES. <br/>Get all users with filter.<br/> For local administrators this will implicitly filter users in the prison's they administer, therefore username is expected in the authorisation token. <br/>For users with role ROLE_MAINTAIN_ACCESS_ROLES_ADMIN this allows access to all staff.",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Pageable list of user summaries",
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "Incorrect filter supplied",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))]
+      )
+    ]
+  )
+  fun getUsers(
+    @PageableDefault
+    pageRequest: Pageable,
+    @RequestParam(value = "nameFilter", required = false)
+    @Schema(
+      description = "Filter results by first name and/or username and/or last name of staff member",
+      example = "Raj"
+    )
+    nameFilter: String?,
+    @RequestParam(value = "accessRoles", required = false)
+    @Schema(
+      description = "Filter will match users that have all DPS role specified",
+      example = "ADD_SENSITIVE_CASE_NOTES"
+    )
+    accessRoles: List<String>?,
+    @RequestParam(value = "status", required = false, defaultValue = "ALL")
+    @Schema(
+      description = "Limit to active / inactive / show all users.",
+      allowableValues = ["ACTIVE", "INACTIVE", "ALL"],
+      defaultValue = "ALL",
+      example = "INACTIVE"
+    )
+    status: UserStatus = UserStatus.ACTIVE,
+    @Schema(
+      description = "Filter results by user's currently active caseload i.e. the one they have currently selected",
+      example = "MDI"
+    )
+    @RequestParam(value = "activeCaseload", required = false) activeCaseload: String?,
+    @Schema(
+      description = "Filter results to include only those users that have access to the specified caseload (irrespective of whether it is currently active or not",
+      example = "MDI"
+    )
+    @RequestParam(value = "caseload", required = false) caseload: String?,
+  ): Page<UserSummary> {
+    return userService.getLocalUsers(
+      pageRequest,
+      authenticationFacade.currentUsername ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST)
+    )
+  }
 }
 
 @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/service/UserService.kt
@@ -1,13 +1,13 @@
 package uk.gov.justice.digital.hmpps.nomisuserrolesapi.service
 
+import UserFilter
+import UserSpecification
 import org.springframework.data.domain.Page
-import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
-import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
-import uk.gov.justice.digital.hmpps.nomisuserrolesapi.data.PrisonCaseload
 import uk.gov.justice.digital.hmpps.nomisuserrolesapi.data.UserSummary
 import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.repository.UserPersonDetailRepository
+import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.transformer.toUserSummary
 import uk.gov.justice.digital.hmpps.nomisuserrolesapi.resource.UserDetail
 import java.util.function.Supplier
 import javax.transaction.Transactional
@@ -17,35 +17,14 @@ import javax.transaction.Transactional
 class UserService(
   private val userPersonDetailRepository: UserPersonDetailRepository
 ) {
-  fun findByUsername(username: String): UserDetail {
-    return userPersonDetailRepository.findById(username)
+  fun findByUsername(username: String): UserDetail =
+    userPersonDetailRepository.findById(username)
       .map { u -> UserDetail(u.username, u.staff.staffId, u.staff.firstName, u.staff.lastName) }
       .orElseThrow(UserNotFoundException("User $username not found"))
-  }
 
-  fun getLocalUsers(pageRequest: Pageable, localAdministratorUsername: String): Page<UserSummary> {
-    val users = userPersonDetailRepository.findByIdOrNull(localAdministratorUsername)
-      ?.let {
-        it.administratorOfUserGroups
-          .flatMap { links -> links.userGroup.members }
-          .map { member ->
-            UserSummary(
-              username = member.user.username,
-              staffId = member.user.staff.staffId,
-              firstName = member.user.staff.firstName,
-              lastName = member.user.staff.lastName,
-              active = member.user.staff.isActive,
-              activeCaseload = member.user.activeCaseLoad?.let { caseload ->
-                PrisonCaseload(
-                  id = caseload.id,
-                  description = caseload.name
-                )
-              },
-            )
-          }
-      } ?: listOf()
-    return PageImpl(users, pageRequest, users.size.toLong())
-  }
+  fun getLocalUsers(pageRequest: Pageable, filter: UserFilter): Page<UserSummary> =
+    userPersonDetailRepository.findAll(UserSpecification(filter), pageRequest)
+      .map { it.toUserSummary() }
 }
 
 class UserNotFoundException(message: String?) :

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/service/UserService.kt
@@ -1,6 +1,12 @@
 package uk.gov.justice.digital.hmpps.nomisuserrolesapi.service
 
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.nomisuserrolesapi.data.PrisonCaseload
+import uk.gov.justice.digital.hmpps.nomisuserrolesapi.data.UserSummary
 import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.repository.UserPersonDetailRepository
 import uk.gov.justice.digital.hmpps.nomisuserrolesapi.resource.UserDetail
 import java.util.function.Supplier
@@ -15,6 +21,30 @@ class UserService(
     return userPersonDetailRepository.findById(username)
       .map { u -> UserDetail(u.username, u.staff.staffId, u.staff.firstName, u.staff.lastName) }
       .orElseThrow(UserNotFoundException("User $username not found"))
+  }
+
+  fun getLocalUsers(pageRequest: Pageable, localAdministratorUsername: String): Page<UserSummary> {
+    val users = userPersonDetailRepository.findByIdOrNull(localAdministratorUsername)
+      ?.let {
+        it.administratorOfUserGroups
+          .flatMap { links -> links.userGroup.members }
+          .map { member ->
+            UserSummary(
+              username = member.user.username,
+              staffId = member.user.staff.staffId,
+              firstName = member.user.staff.firstName,
+              lastName = member.user.staff.lastName,
+              active = member.user.staff.isActive,
+              activeCaseload = member.user.activeCaseLoad?.let { caseload ->
+                PrisonCaseload(
+                  id = caseload.id,
+                  description = caseload.name
+                )
+              },
+            )
+          }
+      } ?: listOf()
+    return PageImpl(users, pageRequest, users.size.toLong())
   }
 }
 

--- a/src/main/resources/db/migration/V9_1__users.sql
+++ b/src/main/resources/db/migration/V9_1__users.sql
@@ -1,2 +1,0 @@
-insert into STAFF_MEMBERS (STAFF_ID, LAST_NAME, FIRST_NAME) values (1, 'Smith', 'John');
-insert into staff_user_accounts(USERNAME, STAFF_ID, STAFF_USER_TYPE, ID_SOURCE) values ('testuser1', 1, 'GENERAL', 'TAG');

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/helper/EntityDataLoader.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/helper/EntityDataLoader.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.nomisuserrolesapi.helper
 
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
-import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.Caseload
 import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.Staff
 import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.UserCaseload
 import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.UserCaseloadPk
@@ -53,7 +52,7 @@ class GeneralUserBuilder(
               username = userPersonDetail.username
             ),
             startDate = LocalDate.now().minusDays(1),
-            caseload = Caseload(it, ""),
+            caseload = caseloadRepository.findByIdOrNull(it)!!,
             user = userPersonDetail
           )
         }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/helper/EntityDataLoader.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/helper/EntityDataLoader.kt
@@ -1,152 +1,133 @@
 package uk.gov.justice.digital.hmpps.nomisuserrolesapi.helper
 
 import org.springframework.data.repository.findByIdOrNull
-import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.LAAAdminUser
-import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.LAAAdminUserPk
-import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.LAAGeneralUser
-import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.LAAGeneralUserPk
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.Caseload
 import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.Staff
+import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.UserCaseload
+import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.UserCaseloadPk
+import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.UserGroupAdministrator
+import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.UserGroupAdministratorPk
+import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.UserGroupMember
+import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.UserGroupMemberPk
 import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.UserPersonDetail
 import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.repository.CaseloadRepository
-import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.repository.LocalAdminAuthorityRepository
+import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.repository.UserGroupRepository
 import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.repository.UserPersonDetailRepository
 import java.time.LocalDate
 
 class GeneralUserBuilder(
-  private val repository: UserPersonDetailRepository,
-  private val localAdminRepository: LocalAdminAuthorityRepository,
+  repository: UserPersonDetailRepository,
+  private val userGroupRepository: UserGroupRepository,
   private val caseloadRepository: CaseloadRepository,
-  private var userPersonDetail: UserPersonDetail,
-  private var prisonCodes: List<String>,
+  userPersonDetail: UserPersonDetail,
+  prisonCodes: List<String>,
+) : UserBuilder<GeneralUserBuilder>(
+  repository = repository,
+  userPersonDetail = userPersonDetail,
+  prisonCodes = prisonCodes
 ) {
 
-  private fun generalUsersOf(prisonCodes: List<String>): List<LAAGeneralUser> {
+  private fun generalUsersOf(prisonCodes: List<String>): List<UserGroupMember> {
     return prisonCodes.map {
-      LAAGeneralUser(
-        LAAGeneralUserPk(it, this.userPersonDetail.username),
+      UserGroupMember(
+        UserGroupMemberPk(it, this.userPersonDetail.username),
         active = true,
         startDate = LocalDate.now().minusDays(1),
-        authority = localAdminRepository.findByIdOrNull(it)!!,
+        userGroup = userGroupRepository.findByIdOrNull(it)!!,
         user = this.userPersonDetail
       )
     }
   }
 
-  fun build(): GeneralUserBuilder {
+  override fun build(): GeneralUserBuilder {
     userPersonDetail =
       userPersonDetail.copy(
-        administeredLinks = generalUsersOf(prisonCodes),
+        activeAndInactiveMemberOfUserGroups = generalUsersOf(prisonCodes),
         type = "GENERAL",
-        activeCaseLoadId = prisonCodes.first(),
-        caseloads = prisonCodes.map { caseloadRepository.findByIdOrNull(it)!! }
+        activeCaseLoad = prisonCodes.firstOrNull()?.let { caseloadRepository.findByIdOrNull(it) },
+        caseloads = prisonCodes.map {
+          UserCaseload(
+            UserCaseloadPk(
+              caseloadId = it,
+              username = userPersonDetail.username
+            ),
+            startDate = LocalDate.now().minusDays(1),
+            caseload = Caseload(it, ""),
+            user = userPersonDetail
+          )
+        }
       )
-    return this
-  }
-
-  fun save() {
-    repository.saveAndFlush(userPersonDetail)
-  }
-
-  fun buildAndSave() {
-    build()
-    repository.saveAndFlush(userPersonDetail)
-  }
-
-  fun transform(transformer: (UserPersonDetail) -> UserPersonDetail): GeneralUserBuilder {
-    userPersonDetail = transformer(userPersonDetail)
-    return this
-  }
-
-  fun username(username: String): GeneralUserBuilder {
-    this.userPersonDetail = userPersonDetail.copy(username = username)
-    return this
-  }
-
-  fun atPrisons(prisonCodes: List<String>): GeneralUserBuilder {
-    this.prisonCodes = prisonCodes
-    return this
-  }
-
-  fun atPrison(prisonCode: String): GeneralUserBuilder {
-    this.prisonCodes = listOf(prisonCode)
     return this
   }
 }
 
 class LocalAdministratorBuilder(
-  private val repository: UserPersonDetailRepository,
-  private val localAdminRepository: LocalAdminAuthorityRepository,
-  private var userPersonDetail: UserPersonDetail,
-  private var prisonCodes: List<String>,
+  repository: UserPersonDetailRepository,
+  private val userGroupRepository: UserGroupRepository,
+  private val caseloadRepository: CaseloadRepository,
+  userPersonDetail: UserPersonDetail,
+  prisonCodes: List<String>,
+) : UserBuilder<LocalAdministratorBuilder>(
+  repository = repository,
+  userPersonDetail = userPersonDetail,
+  prisonCodes = prisonCodes
 ) {
 
-  private fun adminUsersOf(prisonCodes: List<String>): List<LAAAdminUser> {
+  private fun adminUsersOf(prisonCodes: List<String>): List<UserGroupAdministrator> {
     return prisonCodes.map {
-      LAAAdminUser(
-        LAAAdminUserPk(it, this.userPersonDetail.username),
+      UserGroupAdministrator(
+        UserGroupAdministratorPk(it, this.userPersonDetail.username),
         active = true,
-        authority = localAdminRepository.findByIdOrNull(it)!!
+        userGroup = userGroupRepository.findByIdOrNull(it)!!,
+        user = this.userPersonDetail,
       )
     }
   }
 
-  fun build(): LocalAdministratorBuilder {
+  override fun build(): LocalAdministratorBuilder {
     userPersonDetail =
       userPersonDetail.copy(
-        administratorLinks = adminUsersOf(prisonCodes),
+        activeAndInactiveAdministratorOfUserGroups = adminUsersOf(prisonCodes),
         type = "ADMIN",
-        activeCaseLoadId = prisonCodes.first()
+        activeCaseLoad = prisonCodes.firstOrNull()?.let { caseloadRepository.findByIdOrNull(it) },
       )
     return this
   }
+}
 
-  fun save() {
-    repository.saveAndFlush(userPersonDetail)
-  }
-
-  fun buildAndSave() {
-    build()
-    repository.saveAndFlush(userPersonDetail)
-  }
-
-  fun transform(transformer: (UserPersonDetail) -> UserPersonDetail): LocalAdministratorBuilder {
-    userPersonDetail = transformer(userPersonDetail)
-    return this
-  }
-
-  fun username(username: String): LocalAdministratorBuilder {
-    this.userPersonDetail = userPersonDetail.copy(username = username)
-    return this
-  }
-
-  fun atPrisons(prisonCodes: List<String>): LocalAdministratorBuilder {
-    this.prisonCodes = prisonCodes
-    return this
-  }
-
-  fun atPrison(prisonCode: String): LocalAdministratorBuilder {
-    this.prisonCodes = listOf(prisonCode)
-    return this
+@Component
+class DataBuilder(
+  private val repository: UserPersonDetailRepository,
+  private val userGroupRepository: UserGroupRepository,
+  private val caseloadRepository: CaseloadRepository,
+) {
+  fun generalUser() = generalUserEntityCreator(repository, userGroupRepository, caseloadRepository)
+  fun localAdministrator() = localAdministratorEntityCreator(repository, userGroupRepository, caseloadRepository)
+  fun deleteUsers(vararg username: String) {
+    repository.deleteAllById(username.asIterable())
+    repository.flush()
   }
 }
 
 fun generalUserEntityCreator(
   repository: UserPersonDetailRepository,
-  localAdminRepository: LocalAdminAuthorityRepository,
+  userGroupRepository: UserGroupRepository,
   caseloadRepository: CaseloadRepository,
   userPersonDetail: UserPersonDetail = defaultPerson(),
   prisonCodes: List<String> = listOf("WWI"),
 ): GeneralUserBuilder {
-  return GeneralUserBuilder(repository, localAdminRepository, caseloadRepository, userPersonDetail, prisonCodes)
+  return GeneralUserBuilder(repository, userGroupRepository, caseloadRepository, userPersonDetail, prisonCodes)
 }
 
 fun localAdministratorEntityCreator(
   repository: UserPersonDetailRepository,
-  localAdminRepository: LocalAdminAuthorityRepository,
+  userGroupRepository: UserGroupRepository,
+  caseloadRepository: CaseloadRepository,
   userPersonDetail: UserPersonDetail = defaultPerson(),
   prisonCodes: List<String> = listOf("WWI"),
 ): LocalAdministratorBuilder {
-  return LocalAdministratorBuilder(repository, localAdminRepository, userPersonDetail, prisonCodes)
+  return LocalAdministratorBuilder(repository, userGroupRepository, caseloadRepository, userPersonDetail, prisonCodes)
 }
 
 fun defaultPerson(): UserPersonDetail {
@@ -155,4 +136,59 @@ fun defaultPerson(): UserPersonDetail {
     staff = Staff(firstName = "John", lastName = "Smith", status = "ACTIVE"),
     type = "GENERAL"
   )
+}
+
+abstract class UserBuilder<T>(
+  private val repository: UserPersonDetailRepository,
+  internal var userPersonDetail: UserPersonDetail,
+  internal var prisonCodes: List<String>,
+) {
+
+  fun save(): UserPersonDetail {
+    repository.saveAndFlush(userPersonDetail)
+    return userPersonDetail
+  }
+
+  abstract fun build(): UserBuilder<T>
+
+  fun buildAndSave(): UserPersonDetail {
+    build()
+    repository.saveAndFlush(userPersonDetail)
+    return userPersonDetail
+  }
+
+  fun transform(transformer: (UserPersonDetail) -> UserPersonDetail): UserBuilder<T> {
+    userPersonDetail = transformer(userPersonDetail)
+    return this
+  }
+
+  fun username(username: String): UserBuilder<T> {
+    this.userPersonDetail = userPersonDetail.copy(username = username)
+    return this
+  }
+
+  fun atPrisons(prisonCodes: List<String>): UserBuilder<T> {
+    this.prisonCodes = prisonCodes
+    return this
+  }
+
+  fun atPrison(prisonCode: String): UserBuilder<T> {
+    this.prisonCodes = listOf(prisonCode)
+    return this
+  }
+
+  fun firstName(firstName: String): UserBuilder<T> {
+    this.userPersonDetail = userPersonDetail.copy(staff = userPersonDetail.staff.copy(firstName = firstName))
+    return this
+  }
+
+  fun lastName(lastName: String): UserBuilder<T> {
+    this.userPersonDetail = userPersonDetail.copy(staff = userPersonDetail.staff.copy(lastName = lastName))
+    return this
+  }
+
+  fun inactive(): UserBuilder<T> {
+    this.userPersonDetail = userPersonDetail.copy(staff = userPersonDetail.staff.copy(status = "INACT"))
+    return this
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/helper/EntityDataLoader.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/helper/EntityDataLoader.kt
@@ -104,8 +104,8 @@ class DataBuilder(
 ) {
   fun generalUser() = generalUserEntityCreator(repository, userGroupRepository, caseloadRepository)
   fun localAdministrator() = localAdministratorEntityCreator(repository, userGroupRepository, caseloadRepository)
-  fun deleteUsers(vararg username: String) {
-    repository.deleteAllById(username.asIterable())
+  fun deleteAllUsers(vararg username: String) {
+    repository.deleteAll()
     repository.flush()
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/jpa/repository/UserPersonDetailRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/jpa/repository/UserPersonDetailRepositoryTest.kt
@@ -6,26 +6,24 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.context.annotation.Import
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.test.context.ActiveProfiles
-import uk.gov.justice.digital.hmpps.nomisuserrolesapi.helper.generalUserEntityCreator
-import uk.gov.justice.digital.hmpps.nomisuserrolesapi.helper.localAdministratorEntityCreator
-import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.LAAAdminUser
-import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.LAAGeneralUser
+import uk.gov.justice.digital.hmpps.nomisuserrolesapi.helper.DataBuilder
+import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.UserGroupAdministrator
+import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.UserGroupMember
 import java.time.LocalDate
 import javax.persistence.EntityManager
 
 @DataJpaTest
+@Import(value = [DataBuilder::class])
 @ActiveProfiles("test")
 class UserPersonDetailRepositoryTest {
   @Autowired
   lateinit var repository: UserPersonDetailRepository
 
   @Autowired
-  lateinit var localAdminAuthorityRepository: LocalAdminAuthorityRepository
-
-  @Autowired
-  lateinit var caseloadRepository: CaseloadRepository
+  private lateinit var dataBuilder: DataBuilder
 
   @Autowired
   lateinit var entityManager: EntityManager
@@ -34,7 +32,7 @@ class UserPersonDetailRepositoryTest {
   internal fun `can read a user general user`() {
     assertThat(repository.findByIdOrNull("jim.bubbles")).isNull()
 
-    generalUserEntityCreator(repository, localAdminAuthorityRepository, caseloadRepository)
+    dataBuilder.generalUser()
       .username("jim.bubbles")
       .atPrison("WWI")
       .buildAndSave()
@@ -45,16 +43,16 @@ class UserPersonDetailRepositoryTest {
 
     assertThat(user.username).isEqualTo("jim.bubbles")
     assertThat(user.staff.staffId).isNotNull.isGreaterThan(99L)
-    assertThat(user.administeredLinks).hasSize(1).allMatch { it.id.localAuthorityCode == "WWI" }
-    assertThat(user.administratorLinks).isEmpty()
-    assertThat(user.caseloads).hasSize(1).extracting<String> { it.name }.containsExactly("WANDSWORTH (HMP)")
+    assertThat(user.memberOfUserGroups).hasSize(1).allMatch { it.id.userGroupCode == "WWI" }
+    assertThat(user.administratorOfUserGroups).isEmpty()
+    assertThat(user.caseloads).hasSize(1).extracting<String> { it.caseload.name }.containsExactly("WANDSWORTH (HMP)")
   }
 
   @Test
   internal fun `can read a local administrator user`() {
     assertThat(repository.findByIdOrNull("diane.bubbles")).isNull()
 
-    localAdministratorEntityCreator(repository, localAdminAuthorityRepository)
+    dataBuilder.localAdministrator()
       .username("diane.bubbles")
       .atPrison("WWI")
       .buildAndSave()
@@ -65,31 +63,31 @@ class UserPersonDetailRepositoryTest {
 
     assertThat(user.username).isEqualTo("diane.bubbles")
     assertThat(user.staff.staffId).isNotNull
-    assertThat(user.administratorLinks).hasSize(1).allMatch { it.id.localAuthorityCode == "WWI" }
-    assertThat(user.administeredLinks).isEmpty()
+    assertThat(user.administratorOfUserGroups).hasSize(1).allMatch { it.id.userGroupCode == "WWI" }
+    assertThat(user.memberOfUserGroups).isEmpty()
   }
 
   @Nested
   inner class LocalAdministrators {
     @BeforeEach
     internal fun setupGeneralUsers() {
-      generalUserEntityCreator(repository, localAdminAuthorityRepository, caseloadRepository)
+      dataBuilder.generalUser()
         .username("jane.wwi")
         .atPrison("WWI")
         .buildAndSave()
-      generalUserEntityCreator(repository, localAdminAuthorityRepository, caseloadRepository)
+      dataBuilder.generalUser()
         .username("simon.wwi")
         .atPrison("WWI")
         .buildAndSave()
-      generalUserEntityCreator(repository, localAdminAuthorityRepository, caseloadRepository)
+      dataBuilder.generalUser()
         .username("steve.wwi.bxi")
         .atPrisons(listOf("WWI", "BXI"))
         .buildAndSave()
-      generalUserEntityCreator(repository, localAdminAuthorityRepository, caseloadRepository)
+      dataBuilder.generalUser()
         .username("claire.bxi")
         .atPrison("BXI")
         .buildAndSave()
-      generalUserEntityCreator(repository, localAdminAuthorityRepository, caseloadRepository)
+      dataBuilder.generalUser()
         .username("raj.mdi")
         .atPrison("MDI")
         .buildAndSave()
@@ -97,12 +95,12 @@ class UserPersonDetailRepositoryTest {
 
     @Test
     internal fun `can read a local administrator user that administers general users at multiple prisons`() {
-      localAdministratorEntityCreator(repository, localAdminAuthorityRepository)
+      dataBuilder.localAdministrator()
         .username("jane.bubbles.wwi.bxi")
         .atPrisons(listOf("WWI", "BXI"))
         .buildAndSave()
 
-      localAdministratorEntityCreator(repository, localAdminAuthorityRepository)
+      dataBuilder.localAdministrator()
         .username("hina.bukhari.mdi")
         .atPrison("MDI")
         .buildAndSave()
@@ -111,69 +109,69 @@ class UserPersonDetailRepositoryTest {
 
       val janeBubbles = repository.findByIdOrNull("jane.bubbles.wwi.bxi")!!
 
-      assertThat(janeBubbles.administratorLinks).hasSize(2)
-      assertThat(janeBubbles.administratorLinks.authorityOf("WWI").administeredUsers)
-        .extracting<Pair<String, String>> { it.user.username to it.authority.localAuthorityCode }
+      assertThat(janeBubbles.administratorOfUserGroups).hasSize(2)
+      assertThat(janeBubbles.administratorOfUserGroups.userGroupOf("WWI").members)
+        .extracting<Pair<String, String>> { it.user.username to it.userGroup.id }
         .containsExactly("jane.wwi" to "WWI", "simon.wwi" to "WWI", "steve.wwi.bxi" to "WWI")
-      assertThat(janeBubbles.administratorLinks.authorityOf("BXI").administeredUsers)
-        .extracting<Pair<String, String>> { it.user.username to it.authority.localAuthorityCode }
+      assertThat(janeBubbles.administratorOfUserGroups.userGroupOf("BXI").members)
+        .extracting<Pair<String, String>> { it.user.username to it.userGroup.id }
         .containsExactly("steve.wwi.bxi" to "BXI", "claire.bxi" to "BXI")
 
       val hinaBukhari = repository.findByIdOrNull("hina.bukhari.mdi")!!
 
-      assertThat(hinaBukhari.administratorLinks).hasSize(1)
-      assertThat(hinaBukhari.administratorLinks.authorityOf("MDI").administeredUsers)
+      assertThat(hinaBukhari.administratorOfUserGroups).hasSize(1)
+      assertThat(hinaBukhari.administratorOfUserGroups.userGroupOf("MDI").members)
         .extracting<String> { it.user.username }
         .containsExactly("raj.mdi")
     }
 
     @Test
     internal fun `will filter out local administered prisons where the link is no longer active`() {
-      val makeInactive: (link: LAAAdminUser) -> LAAAdminUser =
+      val makeInactive: (link: UserGroupAdministrator) -> UserGroupAdministrator =
         { it.copy(active = false, expiryDate = LocalDate.now().minusDays(1)) }
-      val makeWWIInactive: (link: LAAAdminUser) -> LAAAdminUser = {
-        if (it.authority.localAuthorityCode == "WWI") makeInactive(it) else it
+      val makeWWIInactive: (link: UserGroupAdministrator) -> UserGroupAdministrator = {
+        if (it.userGroup.id == "WWI") makeInactive(it) else it
       }
 
-      localAdministratorEntityCreator(repository, localAdminAuthorityRepository)
+      dataBuilder.localAdministrator()
         .username("jane.bubbles.wwi.bxi")
         .atPrisons(listOf("WWI", "BXI"))
         .build()
-        .transform { user -> user.copy(administratorLinks = user.administratorLinks.map(makeWWIInactive)) }
+        .transform { user -> user.copy(activeAndInactiveAdministratorOfUserGroups = user.activeAndInactiveAdministratorOfUserGroups.map(makeWWIInactive)) }
         .save()
 
       entityManager.clear()
 
       val janeBubbles = repository.findByIdOrNull("jane.bubbles.wwi.bxi")!!
 
-      assertThat(janeBubbles.allAdministratorLinks).hasSize(2)
-      assertThat(janeBubbles.administratorLinks).hasSize(1)
-      assertThat(janeBubbles.administratorLinks.authorityOf("BXI").administeredUsers)
-        .extracting<Pair<String, String>> { it.user.username to it.authority.localAuthorityCode }
+      assertThat(janeBubbles.activeAndInactiveAdministratorOfUserGroups).hasSize(2)
+      assertThat(janeBubbles.administratorOfUserGroups).hasSize(1)
+      assertThat(janeBubbles.administratorOfUserGroups.userGroupOf("BXI").members)
+        .extracting<Pair<String, String>> { it.user.username to it.userGroup.id }
         .containsExactly("steve.wwi.bxi" to "BXI", "claire.bxi" to "BXI")
     }
 
     @Test
     internal fun `will filter out users whose administration link is no longer active`() {
-      val makeInactive: (link: LAAGeneralUser) -> LAAGeneralUser =
+      val makeInactive: (link: UserGroupMember) -> UserGroupMember =
         { it.copy(active = false, expiryDate = LocalDate.now().minusDays(1)) }
 
-      localAdministratorEntityCreator(repository, localAdminAuthorityRepository)
+      dataBuilder.localAdministrator()
         .username("jane.bubbles.wli")
         .atPrison("WLI")
         .buildAndSave()
 
-      generalUserEntityCreator(repository, localAdminAuthorityRepository, caseloadRepository)
+      dataBuilder.generalUser()
         .username("steve.wli")
         .atPrison("WLI")
         .build()
-        .transform { user -> user.copy(administeredLinks = user.administeredLinks.map { makeInactive(it) }) }
+        .transform { user -> user.copy(activeAndInactiveMemberOfUserGroups = user.activeAndInactiveMemberOfUserGroups.map { makeInactive(it) }) }
         .save()
-      generalUserEntityCreator(repository, localAdminAuthorityRepository, caseloadRepository)
+      dataBuilder.generalUser()
         .username("claire.wli")
         .atPrison("WLI")
         .buildAndSave()
-      generalUserEntityCreator(repository, localAdminAuthorityRepository, caseloadRepository)
+      dataBuilder.generalUser()
         .username("raj.wli")
         .atPrison("WLI")
         .buildAndSave()
@@ -182,13 +180,13 @@ class UserPersonDetailRepositoryTest {
 
       val janeBubbles = repository.findByIdOrNull("jane.bubbles.wli")!!
 
-      assertThat(janeBubbles.administratorLinks.authorityOf("WLI").allAdministeredUsers).hasSize(3)
-      assertThat(janeBubbles.administratorLinks.authorityOf("WLI").administeredUsers)
+      assertThat(janeBubbles.administratorOfUserGroups.userGroupOf("WLI").activeAndInactiveMembers).hasSize(3)
+      assertThat(janeBubbles.administratorOfUserGroups.userGroupOf("WLI").members)
         .extracting<String> { it.user.username }
         .containsExactly("claire.wli", "raj.wli")
     }
   }
 }
 
-fun List<LAAAdminUser>.authorityOf(authorityCode: String) =
-  this.find { it.id.localAuthorityCode == authorityCode }!!.authority
+fun List<UserGroupAdministrator>.userGroupOf(userGroupCode: String) =
+  this.find { it.id.userGroupCode == userGroupCode }!!.userGroup

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/jpa/transformer/TransformersKtTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/jpa/transformer/TransformersKtTest.kt
@@ -1,0 +1,50 @@
+package uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.transformer
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.nomisuserrolesapi.data.PrisonCaseload
+import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.Caseload
+import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.Staff
+import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.UserPersonDetail
+
+internal class TransformersKtTest {
+
+  @Nested
+  @DisplayName("toUserSummary")
+  inner class ToUserSummary {
+    @Test
+    fun `will copy summary data`() {
+      val entity = UserPersonDetail(
+        username = "raj.maki",
+        staff = Staff(staffId = 99, firstName = "Raj", lastName = "Maki", status = "ACTIVE"),
+        type = "GENERAL",
+        activeCaseLoad = Caseload("WWI", "WANDSWORTH (HMP)")
+      )
+
+      val data = entity.toUserSummary()
+
+      assertThat(data.username).isEqualTo("raj.maki")
+      assertThat(data.active).isTrue
+      assertThat(data.firstName).isEqualTo("Raj")
+      assertThat(data.lastName).isEqualTo("Maki")
+      assertThat(data.staffId).isEqualTo(99)
+      assertThat(data.activeCaseload).isEqualTo(PrisonCaseload("WWI", "WANDSWORTH (HMP)"))
+    }
+
+    @Test
+    @DisplayName("will not attempt to copy active caseload if not set")
+    internal fun `will not attempt to copy active caseload if not set`() {
+      val entity = UserPersonDetail(
+        username = "raj.maki",
+        staff = Staff(staffId = 99, firstName = "Raj", lastName = "Maki", status = "ACTIVE"),
+        type = "GENERAL",
+      )
+
+      val data = entity.toUserSummary()
+
+      assertThat(data.activeCaseload).isNull()
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/resource/UserResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/resource/UserResourceIntTest.kt
@@ -1,11 +1,17 @@
 package uk.gov.justice.digital.hmpps.nomisuserrolesapi.resource
 
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.nomisuserrolesapi.helper.DataBuilder
 import uk.gov.justice.digital.hmpps.nomisuserrolesapi.integration.IntegrationTestBase
 
 class UserResourceIntTest : IntegrationTestBase() {
+  @Autowired
+  private lateinit var dataBuilder: DataBuilder
 
   @DisplayName("GET /users/{username}")
   @Nested
@@ -61,6 +67,82 @@ class UserResourceIntTest : IntegrationTestBase() {
           }
           """
         )
+    }
+  }
+
+  @DisplayName("GET /users/")
+  @Nested
+  inner class GetUser {
+    @Test
+    fun `access forbidden when no authority`() {
+      webTestClient.get().uri("/users")
+        .exchange()
+        .expectStatus().isUnauthorized
+    }
+
+    @Test
+    fun `access forbidden when no role`() {
+      webTestClient.get().uri("/users")
+        .headers(setAuthorisation(roles = listOf()))
+        .exchange()
+        .expectStatus().isForbidden
+    }
+
+    @Test
+    fun `get user forbidden with wrong role`() {
+      webTestClient.get().uri("/users")
+        .headers(setAuthorisation(roles = listOf("ROLE_BANANAS")))
+        .exchange()
+        .expectStatus().isForbidden
+    }
+
+    @Nested
+    @DisplayName("when called by a national central administrator")
+    inner class NationalCentralAdministrator {
+      @Test
+      fun `a central admin user can call the endpoint with the ROLE_MAINTAIN_ACCESS_ROLES_ADMIN role`() {
+        webTestClient.get().uri("/users/")
+          .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_ACCESS_ROLES_ADMIN")))
+          .exchange()
+          .expectStatus().isOk
+      }
+    }
+
+    @Nested
+    @DisplayName("when called by a local administrator")
+    inner class LocalAdministrator {
+      @BeforeEach
+      internal fun createUsers() {
+        with(dataBuilder) {
+          localAdministrator().username("jane.lsa.wwi").atPrison("WWI").buildAndSave()
+
+          generalUser().username("abella.moulin").firstName("Abella").lastName("Moulin").atPrison("WWI").buildAndSave()
+          generalUser().username("marco.rossi").atPrisons(listOf("WWI", "BXI")).inactive().buildAndSave()
+          generalUser().username("mark.bowlan").atPrison("BXI").buildAndSave()
+        }
+      }
+
+      @AfterEach
+      internal fun deleteUsers() =
+        dataBuilder.deleteUsers("jane.lsa.wwi", "abella.moulin", "marco.rossi", "mark.bowlan")
+
+      @Test
+      fun `a local administrator user can call the endpoint with the ROLE_MAINTAIN_ACCESS_ROLES role`() {
+        val matchByUserName = "$.content[?(@.username == '%s')]"
+
+        webTestClient.get().uri("/users/")
+          .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_ACCESS_ROLES"), user = "jane.lsa.wwi"))
+          .exchange()
+          .expectStatus().isOk
+          .expectBody()
+          .jsonPath("$.numberOfElements").isEqualTo(2)
+          .jsonPath(matchByUserName, "marco.rossi").exists()
+          .jsonPath(matchByUserName, "abella.moulin").exists()
+          .jsonPath(matchByUserName + "active", "abella.moulin").isEqualTo(true)
+          .jsonPath(matchByUserName + "firstName", "abella.moulin").isEqualTo("Abella")
+          .jsonPath(matchByUserName + "lastName", "abella.moulin").isEqualTo("Moulin")
+          .jsonPath(matchByUserName + "staffId", "abella.moulin").exists()
+      }
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/resource/UserResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/resource/UserResourceIntTest.kt
@@ -16,9 +16,18 @@ class UserResourceIntTest : IntegrationTestBase() {
   @DisplayName("GET /users/{username}")
   @Nested
   inner class GetUserByUsername {
+    @BeforeEach
+    internal fun createUsers() {
+      with(dataBuilder) {
+        generalUser().username("marco.rossi").firstName("Marco").lastName("Rossi").buildAndSave()
+      }
+    }
+    @AfterEach
+    internal fun deleteUsers() = dataBuilder.deleteAllUsers()
+
     @Test
     fun `access forbidden when no authority`() {
-      webTestClient.get().uri("/users/testuser1")
+      webTestClient.get().uri("/users/marco.rossi")
         .exchange()
         .expectStatus().isUnauthorized
     }
@@ -26,7 +35,7 @@ class UserResourceIntTest : IntegrationTestBase() {
     @Test
     fun `access forbidden when no role`() {
 
-      webTestClient.get().uri("/users/testuser1")
+      webTestClient.get().uri("/users/marco.rossi")
         .headers(setAuthorisation(roles = listOf()))
         .exchange()
         .expectStatus().isForbidden
@@ -35,7 +44,7 @@ class UserResourceIntTest : IntegrationTestBase() {
     @Test
     fun `get user forbidden with wrong role`() {
 
-      webTestClient.get().uri("/users/testuser1")
+      webTestClient.get().uri("/users/marco.rossi")
         .headers(setAuthorisation(roles = listOf("ROLE_BANANAS")))
         .exchange()
         .expectStatus().isForbidden
@@ -53,26 +62,22 @@ class UserResourceIntTest : IntegrationTestBase() {
     @Test
     fun `get user`() {
 
-      webTestClient.get().uri("/users/testuser1")
+      webTestClient.get().uri("/users/marco.rossi")
         .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_ACCESS_ROLES_ADMIN")))
         .exchange()
         .expectStatus().isOk
-        .expectBody().json(
-          """
-          {
-          "username": "testuser1",
-          "staffId": 1,
-          "firstName": "John",
-          "lastName": "Smith"
-          }
-          """
-        )
+        .expectBody()
+        .jsonPath("username").isEqualTo("marco.rossi")
+        .jsonPath("firstName").isEqualTo("Marco")
+        .jsonPath("lastName").isEqualTo("Rossi")
+        .jsonPath("staffId").exists()
     }
   }
 
   @DisplayName("GET /users/")
   @Nested
   inner class GetUser {
+    val matchByUserName = "$.content[?(@.username == '%s')]"
     @Test
     fun `access forbidden when no authority`() {
       webTestClient.get().uri("/users")
@@ -99,12 +104,28 @@ class UserResourceIntTest : IntegrationTestBase() {
     @Nested
     @DisplayName("when called by a national central administrator")
     inner class NationalCentralAdministrator {
+      @BeforeEach
+      internal fun createUsers() {
+        with(dataBuilder) {
+          generalUser().username("abella.moulin").firstName("Abella").lastName("Moulin").atPrison("WWI").buildAndSave()
+          generalUser().username("marco.rossi").atPrisons(listOf("WWI", "BXI")).inactive().buildAndSave()
+          generalUser().username("mark.bowlan").atPrison("BXI").buildAndSave()
+        }
+      }
+      @AfterEach
+      internal fun deleteUsers() = dataBuilder.deleteAllUsers()
+
       @Test
       fun `a central admin user can call the endpoint with the ROLE_MAINTAIN_ACCESS_ROLES_ADMIN role`() {
         webTestClient.get().uri("/users/")
           .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_ACCESS_ROLES_ADMIN")))
           .exchange()
           .expectStatus().isOk
+          .expectBody()
+          .jsonPath("$.numberOfElements").isEqualTo(3)
+          .jsonPath(matchByUserName, "marco.rossi").exists()
+          .jsonPath(matchByUserName, "abella.moulin").exists()
+          .jsonPath(matchByUserName, "mark.bowlan").exists()
       }
     }
 
@@ -123,13 +144,10 @@ class UserResourceIntTest : IntegrationTestBase() {
       }
 
       @AfterEach
-      internal fun deleteUsers() =
-        dataBuilder.deleteUsers("jane.lsa.wwi", "abella.moulin", "marco.rossi", "mark.bowlan")
+      internal fun deleteUsers() = dataBuilder.deleteAllUsers()
 
       @Test
       fun `a local administrator user can call the endpoint with the ROLE_MAINTAIN_ACCESS_ROLES role`() {
-        val matchByUserName = "$.content[?(@.username == '%s')]"
-
         webTestClient.get().uri("/users/")
           .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_ACCESS_ROLES"), user = "jane.lsa.wwi"))
           .exchange()
@@ -142,6 +160,23 @@ class UserResourceIntTest : IntegrationTestBase() {
           .jsonPath(matchByUserName + "firstName", "abella.moulin").isEqualTo("Abella")
           .jsonPath(matchByUserName + "lastName", "abella.moulin").isEqualTo("Moulin")
           .jsonPath(matchByUserName + "staffId", "abella.moulin").exists()
+          .jsonPath(matchByUserName + "staffId", "abella.moulin").exists()
+          .jsonPath(matchByUserName + "activeCaseload.id", "abella.moulin").isEqualTo("WWI")
+          .jsonPath(matchByUserName + "activeCaseload.name", "abella.moulin").isEqualTo("WANDSWORTH (HMP)")
+      }
+
+      @Test
+      internal fun `a local administrator would see all users, including themselves,  if they have the nation admin role`() {
+        webTestClient.get().uri("/users/")
+          .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_ACCESS_ROLES_ADMIN"), user = "jane.lsa.wwi"))
+          .exchange()
+          .expectStatus().isOk
+          .expectBody()
+          .jsonPath("$.numberOfElements").isEqualTo(4)
+          .jsonPath(matchByUserName, "marco.rossi").exists()
+          .jsonPath(matchByUserName, "abella.moulin").exists()
+          .jsonPath(matchByUserName, "mark.bowlan").exists()
+          .jsonPath(matchByUserName, "jane.lsa.wwi").exists()
       }
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/resource/UserResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/resource/UserResourceTest.kt
@@ -5,12 +5,14 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.nomisuserrolesapi.config.AuthenticationFacade
 import uk.gov.justice.digital.hmpps.nomisuserrolesapi.service.UserService
 
 class UserResourceTest {
 
   private val userService: UserService = mock()
-  private val userResource = UserResource(userService)
+  private val authenticationFacade: AuthenticationFacade = mock()
+  private val userResource = UserResource(userService, authenticationFacade)
 
   @Test
   fun `Get user details`() {


### PR DESCRIPTION
* Refactor the general user administration names so there is a concept of a `UserGroup` with `members` and `administrators`
* Refactor of entity builder so wrapped in a Spring bean and added super class for the two different flavours of users
* Added basic JPA specification just for LSA searches
* E2E test for the basic LSA and Central admin users

TODO
* The various filters
* Paging tests