### PR TITLE
DT-2616 search users - add name filter

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/config/NomisUserRolesApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/config/NomisUserRolesApiExceptionHandler.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.nomisuserrolesapi.config
 
 import org.slf4j.LoggerFactory
+import org.springframework.beans.TypeMismatchException
 import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatus.BAD_REQUEST
 import org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR
@@ -45,7 +46,7 @@ class NomisUserRolesApiExceptionHandler {
   }
 
   @ExceptionHandler(ValidationException::class)
-  fun handleValidationException(e: Exception): ResponseEntity<ErrorResponse> {
+  fun handleValidationException(e: ValidationException): ResponseEntity<ErrorResponse> {
     log.info("Validation exception: {}", e.message)
     return ResponseEntity
       .status(BAD_REQUEST)
@@ -53,6 +54,20 @@ class NomisUserRolesApiExceptionHandler {
         ErrorResponse(
           status = BAD_REQUEST,
           userMessage = "Validation failure: ${e.message}",
+          developerMessage = e.message
+        )
+      )
+  }
+
+  @ExceptionHandler(TypeMismatchException::class)
+  fun handleValidationException(e: TypeMismatchException): ResponseEntity<ErrorResponse> {
+    log.info("Parameter conversion exception: {}", e.message)
+    return ResponseEntity
+      .status(BAD_REQUEST)
+      .body(
+        ErrorResponse(
+          status = BAD_REQUEST,
+          userMessage = "Parameter conversion failure: ${e.message}",
           developerMessage = e.message
         )
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/data/filter/UserFilter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/data/filter/UserFilter.kt
@@ -1,3 +1,9 @@
 package uk.gov.justice.digital.hmpps.nomisuserrolesapi.data.filter
 
-data class UserFilter(val localAdministratorUsername: String? = null, val name: String? = null)
+import uk.gov.justice.digital.hmpps.nomisuserrolesapi.data.UserStatus
+
+data class UserFilter(
+  val localAdministratorUsername: String? = null,
+  val name: String? = null,
+  val status: UserStatus? = null
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/data/filter/UserFilter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/data/filter/UserFilter.kt
@@ -1,0 +1,3 @@
+package uk.gov.justice.digital.hmpps.nomisuserrolesapi.data.filter
+
+data class UserFilter(val localAdministratorUsername: String? = null, val name: String? = null)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/jpa/specification/UserSpecification.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/jpa/specification/UserSpecification.kt
@@ -103,9 +103,10 @@ class UserSpecification(private val filter: UserFilter) : Specification<UserPers
   }
 }
 
-private fun String.isFullName() = this.split(" ").size > 1
-private fun String.firstWord() = if (isFullName()) this.split(" ")[0] else this
-private fun String.secondWord() =
-  if (isFullName()) this.split(" ")[1] else throw IllegalArgumentException("Term is not got two words")
+private fun String.spiltWords(): List<String> = this.split(",", " ")
+private fun String.isFullName() = this.spiltWords().size > 1
+private fun String.asFullName(): Pair<String, String> = this.spiltWords().let { it[0] to it[1] }
+private fun String.firstWord() = asFullName().first
+private fun String.secondWord() = asFullName().second
 
 private fun String.uppercaseLike() = "${this.uppercase()}%"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/jpa/specification/UserSpecification.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/jpa/specification/UserSpecification.kt
@@ -30,16 +30,20 @@ class UserSpecification(private val filter: UserFilter) : Specification<UserPers
     fun username() = root.get<String>(UserPersonDetail::username.name)
     fun joinToMemberOfUserGroups() =
       root.join<UserPersonDetail, UserGroupMember>(UserPersonDetail::memberOfUserGroups.name)
+
     fun Join<UserPersonDetail, UserGroupMember>.joinToUserGroup() =
       this.join<UserGroupMember, UserGroup>(UserGroupMember::userGroup.name)
+
     fun Join<UserGroupMember, UserGroup>.joinToAdministrators() =
       this.join<UserGroup, UserGroupAdministrator>(UserGroup::administrators.name)
+
     fun <PROP> Path<*>.get(prop: KProperty1<*, PROP>): Path<PROP> = this.get(prop.name)
 
     fun administeredBy(localAdministratorUsername: String): Predicate {
-      val administratorsJoin = joinToMemberOfUserGroups().joinToUserGroup().joinToAdministrators()
       return equal(
-        administratorsJoin
+        joinToMemberOfUserGroups()
+          .joinToUserGroup()
+          .joinToAdministrators()
           .get(UserGroupAdministrator::id)
           .get(UserGroupAdministratorPk::username),
         localAdministratorUsername

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/resource/UserResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/resource/UserResource.kt
@@ -203,7 +203,8 @@ class UserResource(
     pageRequest,
     UserFilter(
       localAdministratorUsername = localAdministratorUsernameWhenNotCentralAdministrator(),
-      name = if (nameFilter.isNullOrBlank()) null else nameFilter
+      name = if (nameFilter.isNullOrBlank()) null else nameFilter,
+      status = status,
     )
   )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/resource/UserResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/resource/UserResource.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.nomisuserrolesapi.resource
 
 import UserFilter
+import com.fasterxml.jackson.annotation.JsonInclude
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
@@ -28,6 +29,7 @@ import uk.gov.justice.digital.hmpps.nomisuserrolesapi.data.CreateUserRequest
 import uk.gov.justice.digital.hmpps.nomisuserrolesapi.data.UserDetail
 import uk.gov.justice.digital.hmpps.nomisuserrolesapi.data.UserStatus
 import uk.gov.justice.digital.hmpps.nomisuserrolesapi.data.UserSummary
+import uk.gov.justice.digital.hmpps.nomisuserrolesapi.data.filter.UserFilter
 import uk.gov.justice.digital.hmpps.nomisuserrolesapi.service.UserService
 import javax.validation.Valid
 import javax.validation.constraints.Size
@@ -201,7 +203,10 @@ class UserResource(
     @RequestParam(value = "caseload", required = false) caseload: String?,
   ): Page<UserSummary> = userService.findUsersByFilter(
     pageRequest,
-    UserFilter(localAdministratorUsername = localAdministratorUsernameWhenNotCentralAdministrator())
+    UserFilter(
+      localAdministratorUsername = localAdministratorUsernameWhenNotCentralAdministrator(),
+      name = if (nameFilter.isNullOrBlank()) null else nameFilter
+    )
   )
   fun localAdministratorUsernameWhenNotCentralAdministrator(): String? = if (AuthenticationFacade.hasRoles("ROLE_MAINTAIN_ACCESS_ROLES_ADMIN")) null else authenticationFacade.currentUsername
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/resource/UserResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/resource/UserResource.kt
@@ -1,7 +1,5 @@
 package uk.gov.justice.digital.hmpps.nomisuserrolesapi.resource
 
-import UserFilter
-import com.fasterxml.jackson.annotation.JsonInclude
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
@@ -208,5 +206,7 @@ class UserResource(
       name = if (nameFilter.isNullOrBlank()) null else nameFilter
     )
   )
-  fun localAdministratorUsernameWhenNotCentralAdministrator(): String? = if (AuthenticationFacade.hasRoles("ROLE_MAINTAIN_ACCESS_ROLES_ADMIN")) null else authenticationFacade.currentUsername
+
+  fun localAdministratorUsernameWhenNotCentralAdministrator(): String? =
+    if (AuthenticationFacade.hasRoles("ROLE_MAINTAIN_ACCESS_ROLES_ADMIN")) null else authenticationFacade.currentUsername
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/service/UserService.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.nomisuserrolesapi.service
 
-import UserFilter
 import UserSpecification
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
@@ -14,6 +13,7 @@ import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.Staff
 import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.UserPersonDetail
 import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.repository.AccountDetailRepository
 import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.repository.CaseloadRepository
+import uk.gov.justice.digital.hmpps.nomisuserrolesapi.data.filter.UserFilter
 import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.repository.UserPersonDetailRepository
 import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.transformer.toUserSummary
 import java.util.function.Supplier

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/service/UserService.kt
@@ -7,13 +7,13 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.nomisuserrolesapi.data.CreateUserRequest
 import uk.gov.justice.digital.hmpps.nomisuserrolesapi.data.UserDetail
 import uk.gov.justice.digital.hmpps.nomisuserrolesapi.data.UserSummary
+import uk.gov.justice.digital.hmpps.nomisuserrolesapi.data.filter.UserFilter
 import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.AccountDetail
 import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.AccountProfile
 import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.Staff
 import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.UserPersonDetail
 import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.repository.AccountDetailRepository
 import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.repository.CaseloadRepository
-import uk.gov.justice.digital.hmpps.nomisuserrolesapi.data.filter.UserFilter
 import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.repository.UserPersonDetailRepository
 import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.transformer.toUserSummary
 import java.util.function.Supplier

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/helper/EntityDataLoader.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/helper/EntityDataLoader.kt
@@ -186,8 +186,10 @@ abstract class UserBuilder<T>(
     return this
   }
 
-  fun inactive(): UserBuilder<T> {
-    this.userPersonDetail = userPersonDetail.copy(staff = userPersonDetail.staff.copy(status = "INACT"))
+  fun inactive(): UserBuilder<T> = status(status = "INACT")
+
+  fun status(status: String): UserBuilder<T> {
+    this.userPersonDetail = userPersonDetail.copy(staff = userPersonDetail.staff.copy(status = status))
     return this
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/jpa/repository/UserPersonDetailRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/jpa/repository/UserPersonDetailRepositoryTest.kt
@@ -356,6 +356,12 @@ class UserPersonDetailRepositoryTest {
         assertThat(usersLastNameFirst.content).extracting<String>(UserPersonDetail::username).containsExactly(
           "SAWYL.ALYCIA",
         )
+
+        val userCommaSeparatedName =
+          repository.findAll(UserSpecification(UserFilter(name = "ALYCIA,sawyl")), PageRequest.of(0, 10))
+        assertThat(userCommaSeparatedName.content).extracting<String>(UserPersonDetail::username).containsExactly(
+          "SAWYL.ALYCIA",
+        )
       }
 
       @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/resource/UserResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/resource/UserResourceIntTest.kt
@@ -111,10 +111,9 @@ class UserResourceIntTest : IntegrationTestBase() {
       @BeforeEach
       internal fun createUsers() {
         with(dataBuilder) {
-          generalUser().username("abella.moulin").firstName("Abella").lastName("Moulin").atPrison("WWI")
-            .buildAndSave()
-          generalUser().username("marco.rossi").atPrisons(listOf("WWI", "BXI")).inactive().buildAndSave()
-          generalUser().username("mark.bowlan").atPrison("BXI").buildAndSave()
+          generalUser().username("abella.moulin").firstName("ABELLA").lastName("MOULIN").atPrison("WWI").buildAndSave()
+          generalUser().username("marco.rossi").firstName("MARCO").lastName("ROSSI").atPrisons(listOf("WWI", "BXI")).inactive().buildAndSave()
+          generalUser().username("mark.bowlan").firstName("MARK").lastName("BOWLAN").atPrison("BXI").buildAndSave()
         }
       }
 
@@ -122,7 +121,7 @@ class UserResourceIntTest : IntegrationTestBase() {
       internal fun deleteUsers() = dataBuilder.deleteAllUsers()
 
       @Test
-      fun `a central admin user can call the endpoint with the ROLE_MAINTAIN_ACCESS_ROLES_ADMIN role`() {
+      fun `they can call the endpoint with the ROLE_MAINTAIN_ACCESS_ROLES_ADMIN role`() {
         webTestClient.get().uri("/users/")
           .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_ACCESS_ROLES_ADMIN")))
           .exchange()
@@ -131,6 +130,17 @@ class UserResourceIntTest : IntegrationTestBase() {
           .jsonPath("$.numberOfElements").isEqualTo(3)
           .jsonPath(matchByUserName, "marco.rossi").exists()
           .jsonPath(matchByUserName, "abella.moulin").exists()
+          .jsonPath(matchByUserName, "mark.bowlan").exists()
+      }
+      @Test
+      fun `they can filter by user name`() {
+        webTestClient.get().uri { it.path("/users/").queryParam("nameFilter", "mar").build() }
+          .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_ACCESS_ROLES_ADMIN")))
+          .exchange()
+          .expectStatus().isOk
+          .expectBody()
+          .jsonPath("$.numberOfElements").isEqualTo(2)
+          .jsonPath(matchByUserName, "marco.rossi").exists()
           .jsonPath(matchByUserName, "mark.bowlan").exists()
       }
     }
@@ -143,10 +153,9 @@ class UserResourceIntTest : IntegrationTestBase() {
         with(dataBuilder) {
           localAdministrator().username("jane.lsa.wwi").atPrison("WWI").buildAndSave()
 
-          generalUser().username("abella.moulin").firstName("Abella").lastName("Moulin").atPrison("WWI")
-            .buildAndSave()
-          generalUser().username("marco.rossi").atPrisons(listOf("WWI", "BXI")).inactive().buildAndSave()
-          generalUser().username("mark.bowlan").atPrison("BXI").buildAndSave()
+          generalUser().username("abella.moulin").firstName("ABELLA").lastName("MOULIN").atPrison("WWI").buildAndSave()
+          generalUser().username("marco.rossi").firstName("MARCO").lastName("ROSSI").atPrisons(listOf("WWI", "BXI")).inactive().buildAndSave()
+          generalUser().username("mark.bowlan").firstName("MARK").lastName("BOWLAN").atPrison("BXI").buildAndSave()
         }
       }
 
@@ -154,7 +163,7 @@ class UserResourceIntTest : IntegrationTestBase() {
       internal fun deleteUsers() = dataBuilder.deleteAllUsers()
 
       @Test
-      fun `a local administrator user can call the endpoint with the ROLE_MAINTAIN_ACCESS_ROLES role`() {
+      fun `they can call the endpoint with the ROLE_MAINTAIN_ACCESS_ROLES role`() {
         webTestClient.get().uri("/users/")
           .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_ACCESS_ROLES"), user = "jane.lsa.wwi"))
           .exchange()
@@ -164,15 +173,15 @@ class UserResourceIntTest : IntegrationTestBase() {
           .jsonPath(matchByUserName, "marco.rossi").exists()
           .jsonPath(matchByUserName, "abella.moulin").exists()
           .jsonPath(matchByUserName + "active", "abella.moulin").isEqualTo(true)
-          .jsonPath(matchByUserName + "firstName", "abella.moulin").isEqualTo("Abella")
-          .jsonPath(matchByUserName + "lastName", "abella.moulin").isEqualTo("Moulin")
+          .jsonPath(matchByUserName + "firstName", "abella.moulin").isEqualTo("ABELLA")
+          .jsonPath(matchByUserName + "lastName", "abella.moulin").isEqualTo("MOULIN")
           .jsonPath(matchByUserName + "staffId", "abella.moulin").exists()
           .jsonPath(matchByUserName + "activeCaseload.id", "abella.moulin").isEqualTo("WWI")
           .jsonPath(matchByUserName + "activeCaseload.name", "abella.moulin").isEqualTo("WANDSWORTH (HMP)")
       }
 
       @Test
-      internal fun `a local administrator would see all users, including themselves,  if they have the nation admin role`() {
+      internal fun `they would see all users, including themselves,  if they have the nation admin role`() {
         webTestClient.get().uri("/users/")
           .headers(
             setAuthorisation(
@@ -188,6 +197,17 @@ class UserResourceIntTest : IntegrationTestBase() {
           .jsonPath(matchByUserName, "abella.moulin").exists()
           .jsonPath(matchByUserName, "mark.bowlan").exists()
           .jsonPath(matchByUserName, "jane.lsa.wwi").exists()
+      }
+
+      @Test
+      fun `they can filter by user name`() {
+        webTestClient.get().uri { it.path("/users/").queryParam("nameFilter", "mar").build() }
+          .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_ACCESS_ROLES"), user = "jane.lsa.wwi"))
+          .exchange()
+          .expectStatus().isOk
+          .expectBody()
+          .jsonPath("$.numberOfElements").isEqualTo(1)
+          .jsonPath(matchByUserName, "marco.rossi").exists()
       }
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/resource/UserResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/resource/UserResourceIntTest.kt
@@ -143,6 +143,24 @@ class UserResourceIntTest : IntegrationTestBase() {
           .jsonPath(matchByUserName, "marco.rossi").exists()
           .jsonPath(matchByUserName, "mark.bowlan").exists()
       }
+      @Test
+      fun `they can filter by account status`() {
+        webTestClient.get().uri { it.path("/users/").queryParam("status", "ACTIVE").build() }
+          .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_ACCESS_ROLES_ADMIN")))
+          .exchange()
+          .expectStatus().isOk
+          .expectBody()
+          .jsonPath("$.numberOfElements").isEqualTo(2)
+          .jsonPath(matchByUserName, "abella.moulin").exists()
+          .jsonPath(matchByUserName, "mark.bowlan").exists()
+      }
+      @Test
+      fun `invalid account status filter is a bad request`() {
+        webTestClient.get().uri { it.path("/users/").queryParam("status", "INACT").build() }
+          .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_ACCESS_ROLES_ADMIN")))
+          .exchange()
+          .expectStatus().isBadRequest
+      }
     }
 
     @Nested
@@ -208,6 +226,16 @@ class UserResourceIntTest : IntegrationTestBase() {
           .expectBody()
           .jsonPath("$.numberOfElements").isEqualTo(1)
           .jsonPath(matchByUserName, "marco.rossi").exists()
+      }
+      @Test
+      fun `they can filter by account status`() {
+        webTestClient.get().uri { it.path("/users/").queryParam("status", "ACTIVE").build() }
+          .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_ACCESS_ROLES"), user = "jane.lsa.wwi"))
+          .exchange()
+          .expectStatus().isOk
+          .expectBody()
+          .jsonPath("$.numberOfElements").isEqualTo(1)
+          .jsonPath(matchByUserName, "abella.moulin").exists()
       }
     }
   }


### PR DESCRIPTION
Adds the ability by name; this is a copy of the existing functionality that allows
* Partial matching on either first name or last name
* Partial matching on username
When the filter passed in contains more than one word it is assumed this is 2 words that is first and last name, both combinations are combined in the search.

* Matching account status


