### PR TITLE
DT-2738 Fixed immutable issue in test using reflection

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/jpa/UserPersonDetail.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/jpa/UserPersonDetail.kt
@@ -30,7 +30,7 @@ data class UserPersonDetail(
   @OneToMany(fetch = FetchType.LAZY)
   @JoinColumn(name = "USERNAME", updatable = false, insertable = false, nullable = false)
   @Where(clause = "CASELOAD_ID = 'NWEB'")
-  val dpsRoles: MutableList<UserCaseloadRole> = mutableListOf(),
+  val dpsRoles: List<UserCaseloadRole> = listOf(),
 
   @OneToMany(fetch = FetchType.LAZY, cascade = [CascadeType.ALL], mappedBy = "user", orphanRemoval = true)
   var caseloads: List<UserCaseload> = listOf(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/helper/EntityTestBuilder.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/helper/EntityTestBuilder.kt
@@ -1,0 +1,43 @@
+package uk.gov.justice.digital.hmpps.nomisuserrolesapi.helper
+
+import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.Caseload
+import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.Role
+import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.Staff
+import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.UsageType
+import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.UserCaseload
+import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.UserCaseloadPk
+import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.UserCaseloadRole
+import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.UserCaseloadRoleIdentity
+import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.UserPersonDetail
+import java.time.LocalDate
+
+fun userPersonalDetails(username: String = "raj.maki", caseLoadId: String = "WWI", roles: List<String> = listOf()) = UserPersonDetail(
+  username = username,
+  staff = Staff(staffId = 99, firstName = "RAJ", lastName = "MAKI", status = "ACTIVE"),
+  type = UsageType.GENERAL,
+  activeCaseLoad = Caseload(caseLoadId, "Prison for $caseLoadId"),
+  dpsRoles = listOf()
+).apply {
+  val userPersonDetail = this
+  // resolve circular immutable reference with reflection cheat (like JPA would do :-) )
+  UserPersonDetail::class.java.getDeclaredField("dpsRoles").apply {
+    this.isAccessible = true
+    this.set(userPersonDetail, roles.mapIndexed { index, roleCode -> userPersonDetail.userCaseloadRole(roleId = index.toLong(), roleCode) })
+  }
+}
+
+private fun UserPersonDetail.userCaseloadRole(
+  roleId: Long = 1,
+  roleCode: String = "APPROVE_CATEGORISATION",
+  caseLoadId: String = "WWI"
+) = UserCaseloadRole(
+  id = UserCaseloadRoleIdentity(roleId, this.username, caseLoadId),
+  role = Role(code = roleCode, name = "description for $roleCode"),
+  UserCaseload(
+    id = UserCaseloadPk(caseloadId = caseLoadId, username = this.username),
+    caseload = Caseload(caseLoadId, "Prison for $caseLoadId"),
+    user = this,
+    roles = listOf(),
+    startDate = LocalDate.now(),
+  )
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/jpa/transformer/TransformersKtTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/jpa/transformer/TransformersKtTest.kt
@@ -5,16 +5,11 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.nomisuserrolesapi.data.PrisonCaseload
+import uk.gov.justice.digital.hmpps.nomisuserrolesapi.helper.userPersonalDetails
 import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.Caseload
-import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.Role
 import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.Staff
 import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.UsageType
-import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.UserCaseload
-import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.UserCaseloadPk
-import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.UserCaseloadRole
-import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.UserCaseloadRoleIdentity
 import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.UserPersonDetail
-import java.time.LocalDate
 
 internal class TransformersKtTest {
 
@@ -39,6 +34,7 @@ internal class TransformersKtTest {
       assertThat(data.staffId).isEqualTo(99)
       assertThat(data.activeCaseload).isNotNull
     }
+
     @Test
     fun `will copy names, caseload and capitalize`() {
       val entity = UserPersonDetail(
@@ -70,32 +66,12 @@ internal class TransformersKtTest {
 
     @Test
     internal fun `will copy the count of all the DPS roles`() {
-      val entity = UserPersonDetail(
-        username = "raj.maki",
-        staff = Staff(staffId = 99, firstName = "RAJ", lastName = "MAKI", status = "ACTIVE"),
-        type = UsageType.GENERAL,
-        activeCaseLoad = Caseload("WWI", "WANDSWORTH (HMP)"),
-      ).apply {
-        this.dpsRoles.add(userCaseloadRole(1))
-        this.dpsRoles.add(userCaseloadRole(2))
-        this.dpsRoles.add(userCaseloadRole(3))
-      }
+      val entity =
+        userPersonalDetails(roles = listOf("APPROVE_CATEGORISATION", "CREATE_CATEGORISATION", "GLOBAL_SEARCH"))
 
       val data = entity.toUserSummary()
 
       assertThat(data.dpsRoleCount).isEqualTo(3)
     }
   }
-
-  private fun UserPersonDetail.userCaseloadRole(roledId: Long) = UserCaseloadRole(
-    id = UserCaseloadRoleIdentity(roledId, "raj.maki", "WANDSWORTH (HMP)"),
-    role = Role(code = "OMIC_ROLE", name = "OMIC Fole"),
-    UserCaseload(
-      id = UserCaseloadPk(caseloadId = "WWI", username = "raj.maki"),
-      caseload = Caseload("WWI", "WANDSWORTH (HMP)"),
-      user = this,
-      roles = listOf(),
-      startDate = LocalDate.now(),
-    )
-  )
 }


### PR DESCRIPTION
This uses the only reasonable method for this scenario:

Entity A has reference to Entity B
Entity B had reference to Entity A

and both are `val` immutable objects.
So we have to fix using reflection with presumably Hibernate does.

This is only used in unit tests