### PR TITLE
DT-2751 add admin roles filter and correct swagger

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/jpa/repository/RoleRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/jpa/repository/RoleRepository.kt
@@ -4,10 +4,11 @@ import org.springframework.data.repository.CrudRepository
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.Role
 import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.RoleType
+import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.UsageType
 import java.util.Optional
 
 @Repository
 interface RoleRepository : CrudRepository<Role, Long> {
   fun findByCode(code: String): Optional<Role>
-  fun findAllByType(type: RoleType): List<Role>
+  fun findAllByTypeAndRoleFunctionIn(type: RoleType, roleFunctions: List<UsageType>): List<Role>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/resource/UserResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/resource/UserResource.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.nomisuserrolesapi.resource
 
 import io.swagger.v3.oas.annotations.Hidden
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
@@ -157,31 +158,29 @@ class UserResource(
     @PageableDefault(sort = ["lastName", "firstName"], direction = Sort.Direction.ASC)
     pageRequest: Pageable,
     @RequestParam(value = "nameFilter", required = false)
-    @Schema(
+    @Parameter(
       description = "Filter results by first name and/or username and/or last name of staff member",
       example = "Raj"
     )
     nameFilter: String?,
     @RequestParam(value = "accessRoles", required = false)
-    @Schema(
+    @Parameter(
       description = "Filter will match users that have all DPS role specified",
       example = "ADD_SENSITIVE_CASE_NOTES"
     )
     accessRoles: List<String>?,
     @RequestParam(value = "status", required = false, defaultValue = "ALL")
-    @Schema(
-      description = "Limit to active / inactive / show all users.",
-      allowableValues = ["ACTIVE", "INACTIVE", "ALL"],
-      defaultValue = "ALL",
+    @Parameter(
+      description = "Limit to active / inactive / show all users",
       example = "INACTIVE"
     )
     status: UserStatus = UserStatus.ACTIVE,
-    @Schema(
+    @Parameter(
       description = "Filter results by user's currently active caseload i.e. the one they have currently selected",
       example = "MDI"
     )
     @RequestParam(value = "activeCaseload", required = false) activeCaseload: String?,
-    @Schema(
+    @Parameter(
       description = "Filter results to include only those users that have access to the specified caseload (irrespective of whether it is currently active or not",
       example = "MDI"
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/service/RoleService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/service/RoleService.kt
@@ -8,6 +8,7 @@ import uk.gov.justice.digital.hmpps.nomisuserrolesapi.data.RoleDetail
 import uk.gov.justice.digital.hmpps.nomisuserrolesapi.data.UpdateRoleRequest
 import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.Role
 import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.RoleType
+import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.UsageType
 import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.getUsageType
 import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.repository.RoleRepository
 import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.transformer.toRoleDetail
@@ -58,8 +59,11 @@ class RoleService(
     }
   }
 
-  fun getAllDPSRoles(): List<RoleDetail> {
-    return roleRepository.findAllByType(RoleType.APP).map {
+  fun getAllDPSRoles(adminRoles: Boolean): List<RoleDetail> {
+    return roleRepository.findAllByTypeAndRoleFunctionIn(
+      RoleType.APP,
+      UsageType.values().toList().filter { adminRoles || it !== UsageType.ADMIN }
+    ).map {
       it.toRoleDetail()
     }
   }


### PR DESCRIPTION
Allow to filter roles so on "GENERAL" DPS roles are returned
Also corrected an issue where Schema swagger annotation was not passing through descriptions