### PR TITLE
DT-2947: add ROLE_MANAGE_NOMIS_USER_ACCOUNT to /users/{username}

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/resource/UserResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/resource/UserResource.kt
@@ -73,12 +73,12 @@ class UserResource(
     @PathVariable @Size(max = 30, min = 1, message = "username must be between 1 and 30") username: String
   ) = userService.deleteUser(username)
 
-  @PreAuthorize("hasRole('ROLE_MAINTAIN_ACCESS_ROLES_ADMIN') or hasRole('ROLE_MAINTAIN_ACCESS_ROLES')")
+  @PreAuthorize("hasRole('ROLE_MANAGE_NOMIS_USER_ACCOUNT') or hasRole('ROLE_MAINTAIN_ACCESS_ROLES')")
   @GetMapping("/{username}")
   @Operation(
     summary = "Get specified user details",
-    description = "Information on a specific user. Requires role ROLE_MAINTAIN_ACCESS_ROLES_ADMIN or ROLE_MAINTAIN_ACCESS_ROLES",
-    security = [SecurityRequirement(name = "MAINTAIN_ACCESS_ROLES_ADMIN"), SecurityRequirement(name = "MAINTAIN_ACCESS_ROLES")],
+    description = "Information on a specific user. Requires role ROLE_MANAGE_NOMIS_USER_ACCOUNT or ROLE_MAINTAIN_ACCESS_ROLES",
+    security = [SecurityRequirement(name = "MANAGE_NOMIS_USER_ACCOUNT"), SecurityRequirement(name = "MAINTAIN_ACCESS_ROLES")],
     responses = [
       ApiResponse(
         responseCode = "200",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/resource/UserAccountResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/resource/UserAccountResourceIntTest.kt
@@ -170,7 +170,7 @@ class UserAccountResourceIntTest : IntegrationTestBase() {
         )
 
       webTestClient.get().uri("/users/TESTUSER2")
-        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_ACCESS_ROLES_ADMIN")))
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_ACCESS_ROLES")))
         .exchange()
         .expectStatus().isOk
         .expectBody()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/resource/UserManagementResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/resource/UserManagementResourceIntTest.kt
@@ -84,7 +84,7 @@ class UserManagementResourceIntTest : IntegrationTestBase() {
         .expectStatus().isOk
 
       webTestClient.get().uri("/users/LOCKING_USER1")
-        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_ACCESS_ROLES_ADMIN")))
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_ACCESS_ROLES")))
         .exchange()
         .expectStatus().isOk
         .expectBody()
@@ -115,7 +115,7 @@ class UserManagementResourceIntTest : IntegrationTestBase() {
         .expectStatus().isOk
 
       webTestClient.get().uri("/users/LOCKING_USER1")
-        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_ACCESS_ROLES_ADMIN")))
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_ACCESS_ROLES")))
         .exchange()
         .expectStatus().isOk
         .expectBody()
@@ -199,7 +199,7 @@ class UserManagementResourceIntTest : IntegrationTestBase() {
         .jsonPath("primaryEmail").isEqualTo("newtest@test.com")
 
       webTestClient.get().uri("/users/TEST_DATA_USER1")
-        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_ACCESS_ROLES_ADMIN")))
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_ACCESS_ROLES")))
         .exchange()
         .expectStatus().isOk
         .expectBody()
@@ -389,7 +389,7 @@ class UserManagementResourceIntTest : IntegrationTestBase() {
     fun `can change name of a user that does exist`() {
 
       webTestClient.get().uri("/users/TEST_DATA_USER1")
-        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_ACCESS_ROLES_ADMIN")))
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_ACCESS_ROLES")))
         .exchange()
         .expectStatus().isOk
         .expectBody()
@@ -413,7 +413,7 @@ class UserManagementResourceIntTest : IntegrationTestBase() {
         .jsonPath("firstName").isEqualTo("NEWFIRSTNAME")
 
       webTestClient.get().uri("/users/TEST_DATA_USER1")
-        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_ACCESS_ROLES_ADMIN")))
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_ACCESS_ROLES")))
         .exchange()
         .expectStatus().isOk
         .expectBody()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/resource/UserResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/resource/UserResourceIntTest.kt
@@ -59,7 +59,7 @@ class UserResourceIntTest : IntegrationTestBase() {
     fun `get user not found`() {
 
       webTestClient.get().uri("/users/dummy")
-        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_ACCESS_ROLES_ADMIN")))
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_ACCESS_ROLES")))
         .exchange()
         .expectStatus().isNotFound
     }
@@ -68,7 +68,7 @@ class UserResourceIntTest : IntegrationTestBase() {
     fun `get user`() {
 
       webTestClient.get().uri("/users/marco.rossi")
-        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_ACCESS_ROLES_ADMIN")))
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_ACCESS_ROLES")))
         .exchange()
         .expectStatus().isOk
         .expectBody()
@@ -1020,7 +1020,7 @@ class UserResourceIntTest : IntegrationTestBase() {
         .expectStatus().isOk
 
       webTestClient.get().uri("/users/TESTUSER3")
-        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_ACCESS_ROLES_ADMIN")))
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_ACCESS_ROLES")))
         .exchange()
         .expectStatus().isNotFound
     }


### PR DESCRIPTION
In #45 @Mjwillis added `ROLE_MAINTAIN_ACCESS_ROLES`. I noticed that this endpoint didn't have `ROLE_MANAGE_NOMIS_USER_ACCOUNT` which we have on `findUsersByEmailAddress` and `findUsersByEmailAddressAndUsernames` and these endpoints are called from auth as part of  https://dsdmoj.atlassian.net/browse/DT-2704