### PR TITLE
DT-2998: add admin flag to user detail interface

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/data/UserDetail.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/data/UserDetail.kt
@@ -21,9 +21,10 @@ data class UserDetail(
   @Schema(description = "List of associated DPS Role Codes", required = false) val dpsRoleCodes: List<String>,
   @Schema(description = "Account is not locked", required = true) val accountNonLocked: Boolean,
   @Schema(description = "Credentials are not expired flag", required = true) val credentialsNonExpired: Boolean,
-  @Schema(description = "User is enabled flag", required = true) val enabled: Boolean
+  @Schema(description = "User is enabled flag", required = true) val enabled: Boolean,
+  @Schema(description = "User is admin flag", required = true) val admin: Boolean
 ) {
-  constructor(userPersonDetail: UserPersonDetail, accountDetail: AccountDetail, accountNonLocked: Boolean, credentialsNonExpired: Boolean, enabled: Boolean) :
+  constructor(userPersonDetail: UserPersonDetail, accountDetail: AccountDetail, accountNonLocked: Boolean, credentialsNonExpired: Boolean, enabled: Boolean, admin: Boolean) :
     this(
       username = userPersonDetail.username,
       staffId = userPersonDetail.staff.staffId,
@@ -36,6 +37,7 @@ data class UserDetail(
       dpsRoleCodes = userPersonDetail.dpsRoles.map { it.role.code },
       accountNonLocked = accountNonLocked,
       credentialsNonExpired = credentialsNonExpired,
-      enabled = enabled
+      enabled = enabled,
+      admin = admin
     )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/service/UserService.kt
@@ -555,7 +555,8 @@ class UserService(
       accountDetail,
       isAccountNonLocked(accountDetail.status),
       isCredentialsNonExpired(accountDetail),
-      isEnabled(user, accountDetail.status)
+      isEnabled(user, accountDetail.status),
+      isAdmin(accountDetail)
     )
   }
 
@@ -576,6 +577,8 @@ class UserService(
     return user.staff.isActive && EnumSet.of(AccountStatus.OPEN, AccountStatus.EXPIRED, AccountStatus.EXPIRED_GRACE)
       .contains(accountStatus)
   }
+
+  fun isAdmin(accountDetail: AccountDetail): Boolean = accountDetail.accountProfile === AccountProfile.TAG_ADMIN
 
   private fun checkIfAccountAlreadyExists(username: String) {
     userPersonDetailRepository.findById(username.uppercase())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/resource/UserResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/resource/UserResourceTest.kt
@@ -29,7 +29,8 @@ class UserResourceTest {
     dpsRoleCodes = listOf("ROLE_GLOBAL_SEARCH", "ROLE_ROLES_ADMIN"),
     accountNonLocked = true,
     credentialsNonExpired = true,
-    enabled = true
+    enabled = true,
+    admin = false
   )
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/service/UserServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/service/UserServiceTest.kt
@@ -168,14 +168,14 @@ internal class UserServiceTest {
     @Test
     fun `isAdmin`() {
       val accountDetailIsAdmin = AccountDetail(
-              "user",
-              profile = AccountProfile.TAG_ADMIN.name
+        "user",
+        profile = AccountProfile.TAG_ADMIN.name
       )
       assertThat(userService.isAdmin(accountDetailIsAdmin)).isTrue
 
       val accountDetailIsNotAdmin = AccountDetail(
-              "user",
-              profile = AccountProfile.TAG_GENERAL.name
+        "user",
+        profile = AccountProfile.TAG_GENERAL.name
       )
       assertThat(userService.isAdmin(accountDetailIsNotAdmin)).isFalse
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/service/UserServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/service/UserServiceTest.kt
@@ -165,6 +165,21 @@ internal class UserServiceTest {
       }
     }
 
+    @Test
+    fun `isAdmin`() {
+      val accountDetailIsAdmin = AccountDetail(
+              "user",
+              profile = AccountProfile.TAG_ADMIN.name
+      )
+      assertThat(userService.isAdmin(accountDetailIsAdmin)).isTrue
+
+      val accountDetailIsNotAdmin = AccountDetail(
+              "user",
+              profile = AccountProfile.TAG_GENERAL.name
+      )
+      assertThat(userService.isAdmin(accountDetailIsNotAdmin)).isFalse
+    }
+
     private fun filterSetFromAccountStatuses(accountStatusesToFilter: Set<AccountStatus>) =
       AccountStatus.values().filterNot { accountStatusesToFilter.contains(it) }
   }


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/DT-2998

Logic taken from [hmpps-auth/NomisUserPersonDetails](https://github.com/ministryofjustice/hmpps-auth/blob/a5e82abdefee74b3ec230c86013c6ad1c46a3634/src/main/kotlin/uk/gov/justice/digital/hmpps/oauth2server/nomis/model/NomisUserPersonDetails.kt#L84-L85)