### PR TITLE
HAAR-418 Remove username constraint of 30 chars as causing 400 validation error resulting in 500 error in auth

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/resource/UserCaseloadManagementResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/resource/UserCaseloadManagementResource.kt
@@ -75,7 +75,7 @@ class UserCaseloadManagementResource(
   )
   fun getUserCaseloads(
     @Schema(description = "Username", example = "TEST_USER1", required = true)
-    @PathVariable @Size(max = 30, min = 1, message = "username must be between 1 and 30") username: String
+    @PathVariable username: String
   ): UserCaseloadDetail {
     return userService.getCaseloads(username)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/resource/UserResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/resource/UserResource.kt
@@ -103,7 +103,7 @@ class UserResource(
   )
   fun getUserDetails(
     @Schema(description = "Username", example = "testuser1", required = true)
-    @PathVariable @Size(max = 30, min = 1, message = "username must be between 1 and 30") username: String
+    @PathVariable username: String
   ): UserDetail =
     userService.findByUsername(username)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/resource/UserRoleManagementResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/resource/UserRoleManagementResource.kt
@@ -78,7 +78,7 @@ class UserRoleManagementResource(
   )
   fun getUserRoles(
     @Schema(description = "Username", example = "TEST_USER1", required = true)
-    @PathVariable @Size(max = 30, min = 1, message = "username must be between 1 and 30") username: String,
+    @PathVariable username: String,
     @Schema(name = "include-nomis-roles", description = "Include NOMIS roles", example = "false", required = false, defaultValue = "false")
     @RequestParam(name = "include-nomis-roles", required = false, defaultValue = "false") includeNomisRoles: Boolean = false,
   ): UserRoleDetail {


### PR DESCRIPTION
Signed-off-by: mjwillis <michael.willis@digital.justice.gov.uk>
