### PR TITLE
HAAR-549: Allow Non-Alpha chars('’-) in first and last name

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/resource/UserManagementResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/resource/UserManagementResource.kt
@@ -313,12 +313,12 @@ data class NameDetail(
   @Schema(description = "First name of the user", example = "John", required = true)
   @field:Pattern(
     regexp = "^[A-Za-z'-]{1,35}$",
-    message = "First name must consist of alphabetical characters, hyphen or an apostrophe only and a max 35 chars"
+    message = "First name must consist of alphabetical characters, a hyphen or an apostrophe only and a max 35 chars"
   ) val firstName: String,
   @Schema(description = "Last name of the user", example = "Smith", required = true)
   @field:Pattern(
     regexp = "^[A-Za-z'-]{1,35}$",
-    message = "Last name must consist of alphabetical characters, hyphen or an apostrophe only and a max 35 chars"
+    message = "Last name must consist of alphabetical characters, a hyphen or an apostrophe only and a max 35 chars"
   ) val lastName: String,
 )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/resource/UserManagementResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/resource/UserManagementResource.kt
@@ -312,12 +312,12 @@ class UserManagementResource(
 data class NameDetail(
   @Schema(description = "First name of the user", example = "John", required = true)
   @field:Pattern(
-    regexp = "^[A-Za-z]{1,35}$",
+    regexp = "^[A-Za-z'’-]{1,35}$",
     message = "First name must consist of alphabetical characters only and a max 35 chars"
   ) val firstName: String,
   @Schema(description = "Last name of the user", example = "Smith", required = true)
   @field:Pattern(
-    regexp = "^[A-Za-z']{1,35}$",
+    regexp = "^[A-Za-z'’-]{1,35}$",
     message = "Last name must consist of alphabetical characters or an apostrophe only and a max 35 chars"
   ) val lastName: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/resource/UserManagementResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/resource/UserManagementResource.kt
@@ -312,13 +312,13 @@ class UserManagementResource(
 data class NameDetail(
   @Schema(description = "First name of the user", example = "John", required = true)
   @field:Pattern(
-    regexp = "^[A-Za-z'’-]{1,35}$",
-    message = "First name must consist of alphabetical characters only and a max 35 chars"
+    regexp = "^[A-Za-z'-]{1,35}$",
+    message = "First name must consist of alphabetical characters, hyphen or an apostrophe only and a max 35 chars"
   ) val firstName: String,
   @Schema(description = "Last name of the user", example = "Smith", required = true)
   @field:Pattern(
-    regexp = "^[A-Za-z'’-]{1,35}$",
-    message = "Last name must consist of alphabetical characters or an apostrophe only and a max 35 chars"
+    regexp = "^[A-Za-z'-]{1,35}$",
+    message = "Last name must consist of alphabetical characters, hyphen or an apostrophe only and a max 35 chars"
   ) val lastName: String,
 )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/resource/UserManagementResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/resource/UserManagementResourceIntTest.kt
@@ -437,6 +437,44 @@ class UserManagementResourceIntTest : IntegrationTestBase() {
     }
 
     @Test
+    fun `can change name of a user that includes an hyphen in fist and lastname  name`() {
+      webTestClient.put().uri("/users/TEST_DATA_USER1/change-name")
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_ACCESS_ROLES_ADMIN")))
+        .body(
+          BodyInserters.fromValue(
+            NameDetail(
+              firstName = "Sarah-Louise",
+              lastName = "O'NeilLastName",
+            )
+          )
+        )
+        .exchange()
+        .expectStatus().isOk
+        .expectBody()
+        .jsonPath("firstName").isEqualTo("Sarah-louise")
+        .jsonPath("lastName").isEqualTo("O'neillastname")
+    }
+
+    @Test
+    fun `1can change name of a user that includes an forward apostrophe in lastname  name`() {
+      webTestClient.put().uri("/users/TEST_DATA_USER1/change-name")
+        .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_ACCESS_ROLES_ADMIN")))
+        .body(
+          BodyInserters.fromValue(
+            NameDetail(
+              firstName = "April",
+              lastName = "O’shea",
+            )
+          )
+        )
+        .exchange()
+        .expectStatus().isOk
+        .expectBody()
+        .jsonPath("firstName").isEqualTo("April")
+        .jsonPath("lastName").isEqualTo("O’shea")
+    }
+
+    @Test
     fun `can change name of a user that does exist`() {
 
       webTestClient.get().uri("/users/TEST_DATA_USER1")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/resource/UserManagementResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/resource/UserManagementResourceIntTest.kt
@@ -395,7 +395,7 @@ class UserManagementResourceIntTest : IntegrationTestBase() {
         .expectStatus().is4xxClientError
         .expectBody()
         .jsonPath("userMessage")
-        .isEqualTo("Validation failure: First name must consist of alphabetical characters only and a max 35 chars")
+        .isEqualTo("Validation failure: First name must consist of alphabetical characters, hyphen or an apostrophe only and a max 35 chars")
     }
 
     @Test
@@ -414,7 +414,7 @@ class UserManagementResourceIntTest : IntegrationTestBase() {
         .expectStatus().is4xxClientError
         .expectBody()
         .jsonPath("userMessage")
-        .isEqualTo("Validation failure: Last name must consist of alphabetical characters or an apostrophe only and a max 35 chars")
+        .isEqualTo("Validation failure: Last name must consist of alphabetical characters, hyphen or an apostrophe only and a max 35 chars")
     }
 
     @Test
@@ -456,7 +456,7 @@ class UserManagementResourceIntTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `1can change name of a user that includes an forward apostrophe in lastname  name`() {
+    fun `can change name of a user that includes an forward apostrophe in lastname  name`() {
       webTestClient.put().uri("/users/TEST_DATA_USER1/change-name")
         .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_ACCESS_ROLES_ADMIN")))
         .body(
@@ -468,10 +468,10 @@ class UserManagementResourceIntTest : IntegrationTestBase() {
           )
         )
         .exchange()
-        .expectStatus().isOk
+        .expectStatus().is4xxClientError
         .expectBody()
-        .jsonPath("firstName").isEqualTo("April")
-        .jsonPath("lastName").isEqualTo("O’shea")
+        .jsonPath("userMessage")
+        .isEqualTo("Validation failure: Last name must consist of alphabetical characters, hyphen or an apostrophe only and a max 35 chars")
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/resource/UserManagementResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/resource/UserManagementResourceIntTest.kt
@@ -395,7 +395,7 @@ class UserManagementResourceIntTest : IntegrationTestBase() {
         .expectStatus().is4xxClientError
         .expectBody()
         .jsonPath("userMessage")
-        .isEqualTo("Validation failure: First name must consist of alphabetical characters, hyphen or an apostrophe only and a max 35 chars")
+        .isEqualTo("Validation failure: First name must consist of alphabetical characters, a hyphen or an apostrophe only and a max 35 chars")
     }
 
     @Test
@@ -414,7 +414,7 @@ class UserManagementResourceIntTest : IntegrationTestBase() {
         .expectStatus().is4xxClientError
         .expectBody()
         .jsonPath("userMessage")
-        .isEqualTo("Validation failure: Last name must consist of alphabetical characters, hyphen or an apostrophe only and a max 35 chars")
+        .isEqualTo("Validation failure: Last name must consist of alphabetical characters, a hyphen or an apostrophe only and a max 35 chars")
     }
 
     @Test
@@ -437,7 +437,7 @@ class UserManagementResourceIntTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `can change name of a user that includes an hyphen in fist and lastname  name`() {
+    fun `can change name of a user that includes a hyphen in first and lastname name`() {
       webTestClient.put().uri("/users/TEST_DATA_USER1/change-name")
         .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_ACCESS_ROLES_ADMIN")))
         .body(
@@ -456,7 +456,7 @@ class UserManagementResourceIntTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `can change name of a user that includes an forward apostrophe in lastname  name`() {
+    fun `can not change name of a user that includes an forward apostrophe in lastname name`() {
       webTestClient.put().uri("/users/TEST_DATA_USER1/change-name")
         .headers(setAuthorisation(roles = listOf("ROLE_MAINTAIN_ACCESS_ROLES_ADMIN")))
         .body(
@@ -471,7 +471,7 @@ class UserManagementResourceIntTest : IntegrationTestBase() {
         .expectStatus().is4xxClientError
         .expectBody()
         .jsonPath("userMessage")
-        .isEqualTo("Validation failure: Last name must consist of alphabetical characters, hyphen or an apostrophe only and a max 35 chars")
+        .isEqualTo("Validation failure: Last name must consist of alphabetical characters, a hyphen or an apostrophe only and a max 35 chars")
     }
 
     @Test


### PR DESCRIPTION
Allow Non-Alpha chars('’-) in first and last name