### PR TITLE
HAAR-549: Allow non alpha chars

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/data/CreateAdminUserRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/data/CreateAdminUserRequest.kt
@@ -17,13 +17,13 @@ data class CreateAdminUserRequest(
   ) @NotBlank val username: String,
   @Schema(description = "First name of the user, required if linkedUsername is not set", example = "John", required = true)
   @field:Pattern(
-    regexp = "^[A-Za-z]{1,35}$",
-    message = "First name must consist of alphabetical characters only and a max 35 chars"
+    regexp = "^[A-Za-z'-]{1,35}$",
+    message = "First name must consist of alphabetical characters, a hyphen or an apostrophe only and a max 35 chars"
   ) val firstName: String,
   @Schema(description = "Last name of the user, required if linkedUsername is not set", example = "Smith", required = true)
   @field:Pattern(
-    regexp = "^[A-Za-z']{1,35}$",
-    message = "Last name must consist of alphabetical characters or an apostrophe only and a max 35 chars"
+    regexp = "^[A-Za-z'-]{1,35}$",
+    message = "Last name must consist of alphabetical characters, a hyphen or an apostrophe only and a max 35 chars"
   ) val lastName: String,
 
   @Schema(description = "Email Address, required if linkedUsername is not set", example = "test@justice.gov.uk", required = true) @field:Email(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/data/CreateGeneralUserRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/data/CreateGeneralUserRequest.kt
@@ -17,13 +17,13 @@ data class CreateGeneralUserRequest(
   ) @NotBlank val username: String,
   @Schema(description = "First name of the user, required if linkedUsername is not set", example = "John", required = true)
   @field:Pattern(
-    regexp = "^[A-Za-z]{1,35}$",
-    message = "First name must consist of alphabetical characters only and a max 35 chars"
+    regexp = "^[A-Za-z'-]{1,35}$",
+    message = "First name must consist of alphabetical characters, a hyphen or an apostrophe only and a max 35 chars"
   ) val firstName: String,
   @Schema(description = "Last name of the user, required if linkedUsername is not set", example = "Smith", required = true)
   @field:Pattern(
-    regexp = "^[A-Za-z']{1,35}$",
-    message = "Last name must consist of alphabetical characters or an apostrophe only and a max 35 chars"
+    regexp = "^[A-Za-z'-]{1,35}$",
+    message = "Last name must consist of alphabetical characters, a hyphen or an apostrophe only and a max 35 chars"
   ) val lastName: String,
 
   @Schema(description = "Default caseload (a.k.a Prison ID)", example = "BXI", required = true) @field:Size(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/data/CreateLocalAdminUserRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/data/CreateLocalAdminUserRequest.kt
@@ -17,13 +17,13 @@ data class CreateLocalAdminUserRequest(
   ) @NotBlank val username: String,
   @Schema(description = "First name of the user, required if linkedUsername is not set", example = "John", required = true)
   @field:Pattern(
-    regexp = "^[A-Za-z]{1,35}$",
-    message = "First name must consist of alphabetical characters only and a max 35 chars"
+    regexp = "^[A-Za-z'-]{1,35}$",
+    message = "First name must consist of alphabetical characters, a hyphen or an apostrophe only and a max 35 chars"
   ) val firstName: String,
   @Schema(description = "Last name of the user, required if linkedUsername is not set", example = "Smith", required = true)
   @field:Pattern(
-    regexp = "^[A-Za-z']{1,35}$",
-    message = "Last name must consist of alphabetical characters or an apostrophe only and a max 35 chars"
+    regexp = "^[A-Za-z'-]{1,35}$",
+    message = "Last name must consist of alphabetical characters, a hyphen or an apostrophe only and a max 35 chars"
   ) val lastName: String,
 
   @Schema(description = "Email Address, required if linkedUsername is not set", example = "test@justice.gov.uk", required = true) @field:Email(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/resource/UserAccountResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/resource/UserAccountResourceIntTest.kt
@@ -69,8 +69,8 @@ class UserAccountResourceIntTest : IntegrationTestBase() {
         .body(
           BodyInserters.fromValue(
             CreateGeneralUserRequest(
-              username = "testuser2",
-              firstName = "Test",
+              username = "testuser-'2",
+              firstName = "Test-User'",
               lastName = "User",
               defaultCaseloadId = "BXI",
               email = "test@test.com"
@@ -90,8 +90,8 @@ class UserAccountResourceIntTest : IntegrationTestBase() {
           BodyInserters.fromValue(
             CreateLocalAdminUserRequest(
               username = "laauser1",
-              firstName = "Laa",
-              lastName = "U'ser",
+              firstName = "Laa-ln'",
+              lastName = "U'ser-ls",
               email = "laa@test.com",
               localAdminGroup = "PVI"
             )
@@ -103,8 +103,8 @@ class UserAccountResourceIntTest : IntegrationTestBase() {
           """
           {
           "username": "LAAUSER1",
-          "firstName": "Laa",
-          "lastName": "U'ser",
+          "firstName": "Laa-ln'",
+          "lastName": "U'ser-ls",
           "activeCaseloadId" : "CADM_I",
           "primaryEmail": "laa@test.com",
           "accountType": "ADMIN"
@@ -220,8 +220,8 @@ class UserAccountResourceIntTest : IntegrationTestBase() {
           BodyInserters.fromValue(
             CreateAdminUserRequest(
               username = "testuser4",
-              firstName = "Test",
-              lastName = "User",
+              firstName = "Test-'fn",
+              lastName = "User'-ln",
               email = "test@test.com"
             )
           )
@@ -244,8 +244,8 @@ class UserAccountResourceIntTest : IntegrationTestBase() {
         .expectBody(StaffDetail::class.java)
         .returnResult().responseBody!!
 
-      assertThat(staffDetail.firstName).isEqualTo("Test")
-      assertThat(staffDetail.lastName).isEqualTo("User")
+      assertThat(staffDetail.firstName).isEqualTo("Test-'fn")
+      assertThat(staffDetail.lastName).isEqualTo("User'-ln")
       assertThat(staffDetail.primaryEmail).isEqualTo("test@test.com")
       assertThat(staffDetail.status).isEqualTo("ACTIVE")
 
@@ -267,8 +267,8 @@ class UserAccountResourceIntTest : IntegrationTestBase() {
         .expectStatus().isOk
         .expectBody()
         .jsonPath("staffId").exists()
-        .jsonPath("firstName").isEqualTo("Test")
-        .jsonPath("lastName").isEqualTo("User")
+        .jsonPath("firstName").isEqualTo("Test-'fn")
+        .jsonPath("lastName").isEqualTo("User'-ln")
         .jsonPath("primaryEmail").isEqualTo("test@test.com")
         .jsonPath("status").isEqualTo("ACTIVE")
         .jsonPath("generalAccount.username").isEqualTo("TESTUSER5")


### PR DESCRIPTION
Allow non alpha chars('-') for creating DPS users.