### PR TITLE
Switch to JDK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM eclipse-temurin:18-jre-jammy AS builder
+FROM --platform=$BUILDPLATFORM eclipse-temurin:18-jdk-jammy AS builder
 
 ARG BUILD_NUMBER
 ENV BUILD_NUMBER ${BUILD_NUMBER:-1_0_0}
@@ -7,7 +7,7 @@ WORKDIR /app
 ADD . .
 RUN ./gradlew --no-daemon assemble
 
-FROM eclipse-temurin:18-jre-jammy
+FROM eclipse-temurin:18-jdk-jammy
 LABEL maintainer="HMPPS Digital Studio <info@digital.justice.gov.uk>"
 
 ARG BUILD_NUMBER


### PR DESCRIPTION
Switch to JDK

Licences pulls in nomis-user-roles-api as part of its integration builds and runs it with the in memory database.

The H2 migrations require Javac on the classpath to compile the embedded code in the stored procedure definitions, as can be seen [here](https://app.circleci.com/pipelines/github/ministryofjustice/licences/2243/workflows/762a99a8-ce5a-499a-ad0c-466a8e79338d/jobs/17089/steps)

Switching back to JDK to allow container to start up