### PR TITLE
HAAR-904: Locking a user should not change the user status

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/service/UserService.kt
@@ -369,8 +369,7 @@ class UserService(
   }
 
   fun lockUser(username: String) {
-    val user = userPersonDetailRepository.findById(username).orElseThrow(UserNotFoundException("User $username not found"))
-    user.staff.status = Staff.STAFF_STATUS_INACTIVE
+    userPersonDetailRepository.findById(username).orElseThrow(UserNotFoundException("User $username not found"))
     userPersonDetailRepository.lockUser(username)
 
     telemetryClient.trackEvent(


### PR DESCRIPTION
This is to revert a previous change back to how it originally worked to ensure locking of user due to forgotten password does not change the active status of the user.