### PR TITLE
HAAR-1989 Use standard user summary as basis for download information

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/service/UserService.kt
@@ -138,7 +138,7 @@ class UserService(
   fun downloadUserByFilter(filter: UserFilter): List<UserSummaryWithEmail> =
     userPersonDetailRepository.findAll(UserSpecification(filter))
       .map {
-        it.toDownloadUserSummaryWithEmail()
+        it.toUserSummaryWithEmail()
       }
 
   fun createGeneralUser(createUserRequest: CreateGeneralUserRequest): UserSummary {


### PR DESCRIPTION
### What
Use user summary that includes dpsRoleCount in download endpoint

### Why
dpsRoleCount is required in download - current info passing through api defaults to zero