### PR TITLE
Fail safely when the JWT does not include a client-id

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/config/ClientTrackingConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/config/ClientTrackingConfiguration.kt
@@ -40,9 +40,15 @@ class ClientTrackingInterceptor : HandlerInterceptor {
           Span.current().setAttribute("username", it) // username in customDimensions
           Span.current().setAttribute("enduser.id", it) // user_Id at the top level of the request
         }
-        Span.current().setAttribute("clientId", jwtBody.getClaim("client_id").toString())
+
+        val clientId = Optional.ofNullable(jwtBody.getClaim("client_id"))
+        if (clientId.isPresent) {
+          Span.current().setAttribute("clientId", clientId.get().toString())
+        }
       } catch (e: ParseException) {
         log.warn("problem decoding jwt public key for application insights", e)
+      } catch (e: NullPointerException) {
+        log.warn("problem finding the client id for application insights", e)
       }
     }
     return true


### PR DESCRIPTION
CAS2 are writing Gatling performance tests[1]. In order to authenticate those requests into and out of our API we need to replicate the creation of a JWT that’s generated by HMPPS Auth.

This JWT is then passed in our requests to various services such as Delius. Oasys and Nomis User Roles API. Here we need identify the user we’re seeking more information on.

When running the service normally without Gatling this is the JWT we send:

```
{
  "sub": "POM_USER",
  "user_uuid": "bbe845a0-444b-4856-8c7b-f3d86cead916",
  "grant_type": "authorization_code",
  "user_id": "29",
  "user_name": "POM_USER",
  "scope": [
    "read",
    "write"
  ],
  "auth_source": "nomis",
  "iss": "http://localhost:9091/auth/issuer",
  "exp": 1713359935,
  "authorities": [
    "ROLE_POM",
    "ROLE_PRISON"
  ],
  "jti": "123",
  "client_id": "approved-premises-ui"
}
```

When we create a JWT within our Gatling tests we get a limited set of data which does not include client_id. We’ve not be able to replicate this expanded version of the JWT so that it matches which would have been our preferred option. Attempts to manually modify the JWT or create a new one of course break the validity of it because HMPPS Auth wasn’t the service to generate or sign it:

```
{
  "jti": "123",
  "sub": "POM_USER",
  "authorities": "ROLE_POM,ROLE_PRISON",
  "name": "Pom User",
  "auth_source": "nomis",
  "user_id": "29",
  "passed_mfa": false,
  "exp": 1713377737
}
```

After unpacking the JWT and getting the user, this service then tries to send telemetery data but it requires a client-id which isn’t present. This omission results in a 500 for our request.

This change makes requests that don’t include a client-id for telemetry return successfully, omitting the client-id safely from telemetery data.

[1] https://github.com/ministryofjustice/hmpps-approved-premises-api/blob/98ed0a1ec3a078043ddd51f551b91cc51e21dd3a/src/gatling/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/gatling/util/Auth.kt#L33