### PR TITLE
Support JWTs from HMPPS Auth when they are limited client_credentials

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/config/AuthAwareTokenConverter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/config/AuthAwareTokenConverter.kt
@@ -33,8 +33,11 @@ class AuthAwareTokenConverter : Converter<Jwt, AbstractAuthenticationToken> {
     val authorities = mutableListOf<GrantedAuthority>().apply { addAll(jwtGrantedAuthoritiesConverter.convert(jwt)!!) }
     if (jwt.claims.containsKey("authorities")) {
       @Suppress("UNCHECKED_CAST")
-      val claimAuthorities = (jwt.claims["authorities"] as Collection<String>).toList()
-      authorities.addAll(claimAuthorities.map(::SimpleGrantedAuthority))
+      val claimAuthorities = jwt.claims["authorities"]
+      when (claimAuthorities) {
+        is Collection<*> -> authorities.addAll((claimAuthorities as Collection<String>).map(::SimpleGrantedAuthority))
+        is String -> authorities.addAll(claimAuthorities.split(",").map(String::trim).map(::SimpleGrantedAuthority))
+      }
     }
     return authorities.toSet()
   }


### PR DESCRIPTION
CAS2 are writing load tests for our API but when hitting this API we unexpectedly get an API due to the value of `authorities` .

In normal circumstances where the frontend is involved an OAuth exchange will happen. We start by requesting `client_credentials` by signing the user in via `/auth/sign-in`, this returns a 'basic' JWT. We can also observe this data stored in the browser. I believe the frontend then make an additional request for an `authorization_grant` to get an access token via `/auth/oauth/token`, I believe this returns an expanded and transformed JWT. It has more information about the person and seems to convert the authorities back into an array which is what this app expects.

It does not seem like HMPPS Auth supports the https://auth0.com/docs/get-started/authentication-and-authorization-flow/resource-owner-password-flow which is somewhat expected but means we can't get the access_token via this mechanism either.

Given we are writing API tests and the frontend is not involved we are not able to perform the second part of this exchange, leaving us with a limited JWT:

```
{
  "jti": "123",
  "sub": "POM_USER",
  "authorities": "ROLE_POM,ROLE_PRISON",
  "name": "Pom User",
  "auth_source": "nomis",
  "user_id": "29",
  "passed_mfa": false,
  "exp": 1713377737
}
```

When we pass this in our request to this API our `authorities` are in an unexpected state. This service expects an array but it's set by HMPPS Auth as a concatenated string[1].

We cannot manipulate the contents of the signed JWT and I can see no way to ask HMPPS Auth to return more information in this part of the exchange.

We’ve had to do a similar check in our API[2].

[1] https://github.com/ministryofjustice/hmpps-auth/blob/9b6b16a5cfc3604369280c26dd14ece99749bac0/src/main/kotlin/uk/gov/justice/digital/hmpps/oauth2server/security/JwtAuthenticationHelper.kt#L86
[2] https://github.com/ministryofjustice/hmpps-approved-premises-api/blob/e4a37c52d7a25715801f803186f5ca6798d88b0f/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt#L137