### PR TITLE
Support usernames that are placed in the JWT subject

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/config/AuthAwareTokenConverter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/config/AuthAwareTokenConverter.kt
@@ -22,6 +22,8 @@ class AuthAwareTokenConverter : Converter<Jwt, AbstractAuthenticationToken> {
   private fun findPrincipal(claims: Map<String, Any?>): String {
     return if (claims.containsKey("user_name")) {
       claims["user_name"] as String
+    } else if (claims.containsKey("sub")) {
+      claims["sub"] as String
     } else if (claims.containsKey("user_id")) {
       claims["user_id"] as String
     } else {


### PR DESCRIPTION
HMPPS Auth which creates JWT’s for us will place the username into the `sub`[1].

CAS are writing Gatling performance tests from the API perspective, without a frontend we aren’t able to go through the normal `client_credentials` or `authorization_grant` flows for OAuth. We are left with a limited authentication JWT which does not have the users name in `user_name`. It is however always placed in `sub` in all variations of JWT so before checking for the user_id we do a check for `sub`.

In the Nomis Roles API service, when requesting the `/me` endpoint a lack of a username is a critical failure since it only searches by username[2], not by user id. It asks the `authenticationFacade` for the principal and assumes it will always be a username but in fact it can be a user_id[3] in our scenario.

[1] https://github.com/ministryofjustice/hmpps-auth/blob/9b6b16a5cfc3604369280c26dd14ece99749bac0/src/main/kotlin/uk/gov/justice/digital/hmpps/oauth2server/security/JwtAuthenticationHelper.kt#L83
[2] https://github.com/ministryofjustice/nomis-user-roles-api/blob/9ccae67d8b908220184ffea0cb98cfd56db3354d/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/resource/MeResource.kt#L60
[3] https://github.com/ministryofjustice/nomis-user-roles-api/blob/9ccae67d8b908220184ffea0cb98cfd56db3354d/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/config/AuthenticationFacade.kt#L34