### PR TITLE
updated queries to use @param and named parameter syntax

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/jpa/repository/RoleRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/jpa/repository/RoleRepository.kt
@@ -10,5 +10,6 @@ import java.util.Optional
 @Repository
 interface RoleRepository : CrudRepository<Role, Long> {
   fun findByCode(code: String): Optional<Role>
+
   fun findAllByTypeAndRoleFunctionIn(type: RoleType, roleFunctions: List<UsageType>): List<Role>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/jpa/repository/UserBasicDetailsRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/jpa/repository/UserBasicDetailsRepository.kt
@@ -4,6 +4,7 @@ import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.AccountStatus
 import java.util.Optional
@@ -13,15 +14,15 @@ interface UserBasicDetailsRepository : JpaRepository<UserBasicPersonalDetail, St
 
   @Query(
     value =
-    " SELECT sua.USERNAME as username, sua.WORKING_CASELOAD_ID as activeCaseloadId, du.ACCOUNT_STATUS as accountStatus, sua.STAFF_ID as staffId, sm.FIRST_NAME as firstName, sm.LAST_NAME as lastName" +
+    "SELECT sua.USERNAME as username, sua.WORKING_CASELOAD_ID as activeCaseloadId, du.ACCOUNT_STATUS as accountStatus, sua.STAFF_ID as staffId, sm.FIRST_NAME as firstName, sm.LAST_NAME as lastName" +
       " FROM STAFF_USER_ACCOUNTS sua " +
       "      LEFT JOIN  DBA_USERS du  ON sua.USERNAME = du.USERNAME  " +
       "     JOIN STAFF_MEMBERS sm ON sm.STAFF_ID = sua.STAFF_ID  " +
       "WHERE " +
-      "     sua.USERNAME= ?1",
+      "     sua.USERNAME= :username",
     nativeQuery = true,
   )
-  fun find(username: String): Optional<UserBasicPersonalDetail>
+  fun find(@Param("username") username: String): Optional<UserBasicPersonalDetail>
 }
 
 @Entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/jpa/repository/UserPersonDetailRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/jpa/repository/UserPersonDetailRepository.kt
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.AccountProfile
 import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.UserPersonDetail
@@ -27,49 +28,53 @@ interface UserPersonDetailRepository :
     value = "call oms_utils.record_logon_date(:username)",
     nativeQuery = true,
   )
-  fun recordLogonDate(username: String)
+  fun recordLogonDate(@Param("username") username: String)
 
   @Modifying
   @Query(
     value = "call oms_utils.create_user(:username, :password, :profile)",
     nativeQuery = true,
   )
-  fun createUser(username: String, password: String, profile: String = AccountProfile.TAG_GENERAL.name)
+  fun createUser(
+    @Param("username") username: String,
+    @Param("password") password: String,
+    @Param("profile") profile: String = AccountProfile.TAG_GENERAL.name
+  )
 
   @Modifying
   @Query(
     value = "call oms_utils.expire_password(:username)",
     nativeQuery = true,
   )
-  fun expirePassword(username: String)
+  fun expirePassword(@Param("username") username: String)
 
   @Modifying
   @Query(
     value = "call oms_utils.drop_user(:username)",
     nativeQuery = true,
   )
-  fun dropUser(username: String)
+  fun dropUser(@Param("username") username: String)
 
   @Modifying
   @Query(
     value = "call oms_utils.change_user_password(:username, :password)",
     nativeQuery = true,
   )
-  fun changePassword(username: String?, password: String?)
+  fun changePassword(@Param("username") username: String?, @Param("password") password: String?)
 
   @Modifying
   @Query(
     value = "call oms_utils.unlock_user(:username)",
     nativeQuery = true,
   )
-  fun unlockUser(username: String?)
+  fun unlockUser(@Param("username") username: String?)
 
   @Modifying
   @Query(
     value = "call oms_utils.lock_user(:username)",
     nativeQuery = true,
   )
-  fun lockUser(username: String?)
+  fun lockUser(@Param("username") username: String?)
 
   @EntityGraph(value = "user-person-detail-download-graph", type = EntityGraph.EntityGraphType.LOAD)
   override fun findAll(speci: Specification<UserPersonDetail>?): List<UserPersonDetail>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/jpa/repository/UserPersonDetailRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/jpa/repository/UserPersonDetailRepository.kt
@@ -38,7 +38,7 @@ interface UserPersonDetailRepository :
   fun createUser(
     @Param("username") username: String,
     @Param("password") password: String,
-    @Param("profile") profile: String = AccountProfile.TAG_GENERAL.name
+    @Param("profile") profile: String = AccountProfile.TAG_GENERAL.name,
   )
 
   @Modifying


### PR DESCRIPTION
HAAR-2711: Ensure Nomis User Roles is using prepared statements.

- Updated prepared statements to use named parameter syntax.
- Updated method parameters with `@Params(param_name)` as recommended in the [Spring Jpa documentation ](https://docs.spring.io/spring-data/jpa/reference/jpa/query-methods.html#jpa.named-parameters)