### PR TITLE
HAAR-2658: Update user download querying to improve performance

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/jpa/repository/UserPersonDetailRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/jpa/repository/UserPersonDetailRepository.kt
@@ -11,7 +11,9 @@ import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.AccountProfile
+import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.DPS_CASELOAD
 import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.UserPersonDetail
+import uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.UserPersonDpsRoleCount
 import uk.gov.justice.digital.hmpps.nomisuserrolesapi.service.PasswordValidationException
 import uk.gov.justice.digital.hmpps.nomisuserrolesapi.service.ReusedPasswordException
 import java.sql.SQLException
@@ -78,6 +80,17 @@ interface UserPersonDetailRepository :
 
   @EntityGraph(value = "user-person-detail-download-graph", type = EntityGraph.EntityGraphType.LOAD)
   override fun findAll(speci: Specification<UserPersonDetail>?): List<UserPersonDetail>
+
+  @Query(
+    """
+    SELECT new uk.gov.justice.digital.hmpps.nomisuserrolesapi.jpa.UserPersonDpsRoleCount(ucr.id.username, COUNT(ucr))
+    FROM UserCaseloadRole ucr
+    WHERE ucr.id.username IN :usernames
+    AND ucr.userCaseload.id.caseloadId = '${DPS_CASELOAD}'
+    GROUP BY ucr.id.username
+    """,
+  )
+  fun findUserDpsRolesCountByUsernames(@Param("usernames") usernames: List<String>): List<UserPersonDpsRoleCount>
 
   @Suppress("FunctionName")
   @EntityGraph(value = "user-person-detail-graph", type = EntityGraph.EntityGraphType.FETCH)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/resource/UserResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisuserrolesapi/resource/UserResource.kt
@@ -377,8 +377,6 @@ class UserResource(
 
   @GetMapping("/download")
   fun downloadUsersByFilters(
-    @PageableDefault(sort = ["lastName", "firstName"], direction = Sort.Direction.ASC)
-    pageRequest: Pageable,
     @RequestParam(value = "nameFilter", required = false)
     @Parameter(
       description = "Filter results by name (first name and/or last name in any order), username or email address.",
@@ -443,8 +441,6 @@ class UserResource(
 
   @GetMapping("/download/admins")
   fun downloadGroupAdminsByFilters(
-    @PageableDefault(sort = ["lastName", "firstName"], direction = Sort.Direction.ASC)
-    pageRequest: Pageable,
     @RequestParam(value = "nameFilter", required = false)
     @Parameter(
       description = "Filter results by name (first name and/or last name in any order), username or email address.",


### PR DESCRIPTION
Improvements to user download APIs revolving in how entity results are mapped to response summary:
- updated entity graph definitions to ensure data required is fetched up front instead of relying on lazy loading (which results in fewer additional queries being made)
- fetch dps role counts in a single specific query instead of relying on count of collection in entity (again results in fewer additional queries/more efficient query being run)

Based on service running locally:
Improved performance of `/users/download` call for 15k users from ~6 mins to ~1 min
Improved performance of `/users/download/admins` call for 15k users from ~11 mins to ~1 min
